### PR TITLE
fix: Add default cases to certain switches

### DIFF
--- a/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
@@ -40,6 +40,9 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
       set_fan_mode_(climate::CLIMATE_FAN_AUTO);
       setRequestPacket.setFan(SettingsSetRequestPacket::FAN_AUTO);
       break;
+    default:
+      ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
+      break;
   }
 
   // Mode

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -220,6 +220,9 @@ void MitsubishiUART::processPacket(const StatusGetResponsePacket &packet) {
         // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
         // If the unit overshoots, this still doesn't work.
         break;
+      default:
+        ESP_LOGW(TAG, "Unhandled mode %i.", mode);
+        break;
     }
   }
   // If we're not operating (but not off or in fan mode), we're idle


### PR DESCRIPTION
At present, this component cannot be built on the `esp-idf` platform due to the following error message:

```
In file included from src/esphome/components/mitsubishi_uart/muart_packet.h:6,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp:1:
src/esphome/components/mitsubishi_uart/muart_rawpacket.h:82:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   const uint8_t getLength() const { return length; };
   ^~~~~
In file included from src/esphome/components/mitsubishi_uart/muart_packet.h:6,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:1:
src/esphome/components/mitsubishi_uart/muart_rawpacket.h:82:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   const uint8_t getLength() const { return length; };
   ^~~~~
In file included from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp:1:
src/esphome/components/mitsubishi_uart/muart_packet.h:34:5: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const bool isResponseExpected() const {return responseExpected;};
     ^~~~~
In file included from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:1:
src/esphome/components/mitsubishi_uart/muart_packet.h:34:5: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const bool isResponseExpected() const {return responseExpected;};
     ^~~~~
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp: In member function 'virtual void esphome::mitsubishi_uart::MitsubishiUART::control(const esphome::climate::ClimateCall&)':
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:22:9: error: enumeration value 'CLIMATE_FAN_ON' not handled in switch [-Werror=switch]
   switch(call.get_fan_mode().value()) {
         ^
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:22:9: error: enumeration value 'CLIMATE_FAN_OFF' not handled in switch [-Werror=switch]
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:22:9: error: enumeration value 'CLIMATE_FAN_MIDDLE' not handled in switch [-Werror=switch]
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:22:9: error: enumeration value 'CLIMATE_FAN_FOCUS' not handled in switch [-Werror=switch]
src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp:22:9: error: enumeration value 'CLIMATE_FAN_DIFFUSE' not handled in switch [-Werror=switch]
src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp: In member function 'virtual void esphome::mitsubishi_uart::MitsubishiUART::processPacket(const esphome::mitsubishi_uart::StatusGetResponsePacket&)':
src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp:201:12: error: enumeration value 'CLIMATE_MODE_OFF' not handled in switch [-Werror=switch]
     switch (mode) {
            ^
src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp:201:12: error: enumeration value 'CLIMATE_MODE_FAN_ONLY' not handled in switch [-Werror=switch]
src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp:201:12: error: enumeration value 'CLIMATE_MODE_AUTO' not handled in switch [-Werror=switch]
cc1plus: some warnings being treated as errors
cc1plus: some warnings being treated as errors
In file included from src/esphome/components/mitsubishi_uart/muart_packet.h:6,
                 from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome.h:31,
                 from src/main.cpp:3:
src/esphome/components/mitsubishi_uart/muart_rawpacket.h:82:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   const uint8_t getLength() const { return length; };
   ^~~~~
In file included from src/esphome/components/mitsubishi_uart/mitsubishi_uart.h:10,
                 from src/esphome.h:31,
                 from src/main.cpp:3:
src/esphome/components/mitsubishi_uart/muart_packet.h:34:5: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const bool isResponseExpected() const {return responseExpected;};
     ^~~~~
*** [.pioenvs/air-handler/src/esphome/components/mitsubishi_uart/mitsubishi_uart-climatecall.o] Error 1
*** [.pioenvs/air-handler/src/esphome/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.o] Error 1
```

This pull request aims to fix the errors (at the very least) so it can compile. In an attempt to promote code hygiene, a warning message was added to these switch cases as well.

The use of `esp-idf` was required for my case so I could fit an extra module into my ESP32 firmware - the standard `arduino` platform created a file just slightly too large.