### PR TITLE
Expose Compressor Frequency as a sensor

### DIFF
--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -9,9 +9,11 @@ from esphome.const import (
     CONF_CUSTOM_FAN_MODES,
     CONF_SUPPORTED_FAN_MODES,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_FREQUENCY,
     ENTITY_CATEGORY_CONFIG,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
+    UNIT_HERTZ,
 )
 from esphome.core import coroutine
 
@@ -24,6 +26,7 @@ CONF_TS_UART = "thermostat_uart"
 CONF_SENSORS = "sensors"
 CONF_SENSORS_CURRENT_TEMP = "current_temperature"
 CONF_SENSORS_THERMOSTAT_TEMP = "thermostat_temperature"
+CONF_SENSORS_COMPRESSOR_FREQUENCY = "compressor_frequency"
 
 CONF_SELECTS = "selects"
 CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select" # This is to create a Select object for selecting a source
@@ -78,19 +81,27 @@ SENSORS = {
     CONF_SENSORS_CURRENT_TEMP: (
         "Current Temperature",
         sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        accuracy_decimals=1,
+            unit_of_measurement=UNIT_CELSIUS,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            accuracy_decimals=1,
         )
     ),
     CONF_SENSORS_THERMOSTAT_TEMP: (
         "Thermostat Temperature",
         sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-        accuracy_decimals=1,
+            unit_of_measurement=UNIT_CELSIUS,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+            accuracy_decimals=1,
+        )
+    ),
+    CONF_SENSORS_COMPRESSOR_FREQUENCY: (
+        "Compressor Frequency",
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_HERTZ,
+            device_class=DEVICE_CLASS_FREQUENCY,
+            state_class=STATE_CLASS_MEASUREMENT
         )
     )
 }
@@ -175,11 +186,13 @@ async def to_code(config):
 
     for sensor_designator in SENSORS:
         # Only add the thermostat temp if we have a TS_UART
-        if ((sensor_designator != CONF_SENSORS_THERMOSTAT_TEMP) or (CONF_TS_UART in config)):
-            sensor_conf = config[CONF_SENSORS][sensor_designator]
-            sensor_component = cg.new_Pvariable(sensor_conf[CONF_ID])
-            await sensor.register_sensor(sensor_component, sensor_conf)
-            cg.add(getattr(muart_component, f"set_{sensor_designator}_sensor")(sensor_component))
+        if (sensor_designator == CONF_SENSORS_THERMOSTAT_TEMP) and (CONF_TS_UART not in config):
+            continue
+
+        sensor_conf = config[CONF_SENSORS][sensor_designator]
+        sensor_component = cg.new_Pvariable(sensor_conf[CONF_ID])
+        await sensor.register_sensor(sensor_component, sensor_conf)
+        cg.add(getattr(muart_component, f"set_{sensor_designator}_sensor")(sensor_component))
 
     ### Selects
 

--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -101,7 +101,8 @@ SENSORS = {
         sensor.sensor_schema(
             unit_of_measurement=UNIT_HERTZ,
             device_class=DEVICE_CLASS_FREQUENCY,
-            state_class=STATE_CLASS_MEASUREMENT
+            state_class=STATE_CLASS_MEASUREMENT,
+            disabled_by_default=True
         )
     )
 }

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -232,6 +232,15 @@ void MitsubishiUART::processPacket(const StatusGetResponsePacket &packet) {
   }
 
   publishOnUpdate |= (old_action != action);
+
+  const float old_compressor_frequency = compressor_frequency;
+  compressor_frequency = packet.getCompressorFrequency();
+
+  if (compressor_frequency_sensor) {
+    compressor_frequency_sensor->raw_state = compressor_frequency;
+  }
+
+  publishOnUpdate |= (old_compressor_frequency != compressor_frequency);
 };
 void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -17,6 +17,8 @@ MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp) : hp_uart{*hp_
    */
   target_temperature = NAN;
   current_temperature = NAN;
+
+  compressor_frequency = 0;
 }
 
 // Used to restore state of previous MUART-specific settings (like temperature source or pass-thru mode)
@@ -141,7 +143,6 @@ void MitsubishiUART::doPublish() {
   horizontal_vane_position_select->publish_state(horizontal_vane_position_select->state);
   save_preferences(); // We can save this every time we publish as writes to flash are by default collected and delayed
 
-
   // Check sensors and publish if needed.
   // This is a bit of a hack to avoid needing to publish sensor data immediately as packets arrive.
   // Instead, packet data is written directly to `raw_state` (which doesn't update `state`).  If they
@@ -153,6 +154,10 @@ void MitsubishiUART::doPublish() {
   if (thermostat_temperature_sensor && (thermostat_temperature_sensor->raw_state != thermostat_temperature_sensor->state)) {
     ESP_LOGI(TAG, "Thermostat temp differs, do publish");
     thermostat_temperature_sensor->publish_state(thermostat_temperature_sensor->raw_state);
+  }
+  if (compressor_frequency_sensor && (compressor_frequency_sensor->raw_state != compressor_frequency_sensor->state)) {
+    ESP_LOGI(TAG, "Compressor frequency differs, do publish");
+    compressor_frequency_sensor->publish_state(compressor_frequency_sensor->raw_state);
   }
 }
 

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -34,6 +34,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
    */
   MitsubishiUART(uart::UARTComponent *hp_uart_comp);
 
+  uint8_t compressor_frequency;
+
   // Used to restore state of previous MUART-specific settings (like temperature source or pass-thru mode)
   // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
   void setup() override;
@@ -64,6 +66,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Sensor setters
   void set_current_temperature_sensor(sensor::Sensor *sensor) {current_temperature_sensor = sensor;};
   void set_thermostat_temperature_sensor(sensor::Sensor *sensor) {thermostat_temperature_sensor = sensor;};
+  void set_compressor_frequency_sensor(sensor::Sensor *sensor) {compressor_frequency_sensor = sensor;};
 
   // Select setters
   void set_temperature_source_select(select::Select *select) {temperature_source_select = select;};
@@ -138,6 +141,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Internal sensors
     sensor::Sensor *current_temperature_sensor = nullptr;
     sensor::Sensor *thermostat_temperature_sensor = nullptr;
+    sensor::Sensor *compressor_frequency_sensor = nullptr;
 
     // Selects
     select::Select *temperature_source_select;


### PR DESCRIPTION
Base attempt to expose compressor frequency information to Home Assistant. Unfortunately only returns `0` on my unit, so I don't think I can test this fully.

For units that don't support this, it can be disabled with:

```yml
mitsubishi_uart:
  ...
  sensors:
    compressor_frequency:
      name: compressor_frequency
      internal: true
```

(Maybe it'd be better to have some kind of `features` key to allow enabling/disabling features entirely? e.g. vane information for those of us with air handlers?)