### PR TITLE
Sync in Edge Changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseTab:          Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,171 @@
+---
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
+  -bugprone-signed-char-misuse,
+  -cert-dcl50-cpp,
+  -cert-err33-c,
+  -cert-err58-cpp,
+  -cert-oop57-cpp,
+  -cert-str34-c,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-osx.*,
+  -clang-diagnostic-delete-abstract-non-virtual-dtor,
+  -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-ignored-optimization-argument,
+  -clang-diagnostic-shadow-field,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
+  -concurrency-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-virtual-class-destructor,
+  -fuchsia-multiple-inheritance,
+  -fuchsia-overloaded-operator,
+  -fuchsia-statically-constructed-objects,
+  -fuchsia-default-arguments-declarations,
+  -fuchsia-default-arguments-calls,
+  -google-build-using-namespace,
+  -google-explicit-constructor,
+  -google-readability-braces-around-statements,
+  -google-readability-casting,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -google-runtime-references,
+  -hicpp-*,
+  -llvm-else-after-return,
+  -llvm-header-guard,
+  -llvm-include-order,
+  -llvm-qualified-auto,
+  -llvmlibc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
+  -misc-unused-parameters,
+  -modernize-avoid-c-arrays,
+  -modernize-avoid-bind,
+  -modernize-concat-nested-namespaces,
+  -modernize-return-braced-init-list,
+  -modernize-use-auto,
+  -modernize-use-default-member-init,
+  -modernize-use-equals-default,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -mpi-*,
+  -objc-*,
+  -readability-container-data-pointer,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-redundant-string-init,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+WarningsAsErrors: '*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     google
+CheckOptions:
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
+    value:           0

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+root = true
+
+# general
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# C++
+[*.{cpp,h,tcc}]
+indent_style = space
+indent_size = 2
+
+# Web
+[*.{js,html,css}]
+indent_style = space
+indent_size = 2
+
+# YAML
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+quote_type = double
+
+# JSON
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize line endings to LF in the repository
+* text eol=lf
+*.png binary

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,18 @@
+---
+extends: default
+
+ignore-from-file: .gitignore
+
+rules:
+  document-start: disable
+  empty-lines:
+    level: error
+    max: 1
+    max-start: 0
+    max-end: 1
+  indentation:
+    level: error
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  line-length: disable

--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -101,10 +101,10 @@ SENSORS = {
     ),
     "actual_fan": (
         "Actual Fan Speed",
-        sensor.sensor_schema(
-            device_class=DEVICE_CLASS_SPEED,
+        text_sensor.text_sensor_schema(
+            icon="mdi:fan",
         ),
-        sensor.register_sensor
+        text_sensor.register_text_sensor
     ),
     "service_filter": (
         "Service Filter",

--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, uart, sensor, binary_sensor, select, switch
+from esphome.components import climate, uart, sensor, binary_sensor, text_sensor, select, switch
 from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
@@ -19,14 +19,15 @@ from esphome.const import (
 )
 from esphome.core import coroutine
 
-AUTO_LOAD = ["climate", "select", "sensor", "binary_sensor", "switch"]
-DEPENDENCIES = ["uart", "climate", "sensor", "binary_sensor", "select", "switch"]
+AUTO_LOAD = ["climate", "select", "sensor", "binary_sensor", "text_sensor", "switch"]
+DEPENDENCIES = ["uart", "climate", "sensor", "binary_sensor", "text_sensor", "select", "switch"]
 
 CONF_HP_UART = "heatpump_uart"
 CONF_TS_UART = "thermostat_uart"
 
 CONF_SENSORS = "sensors"
 CONF_SENSORS_THERMOSTAT_TEMP = "thermostat_temperature"
+CONF_SENSORS_ERROR_CODE = "error_code"
 
 CONF_SELECTS = "selects"
 CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select" # This is to create a Select object for selecting a source
@@ -125,6 +126,11 @@ SENSORS = {
         binary_sensor.binary_sensor_schema(),
         binary_sensor.register_binary_sensor
     ),
+    CONF_SENSORS_ERROR_CODE: (
+        "Error Code",
+        text_sensor.text_sensor_schema(),
+        text_sensor.register_text_sensor
+    )
 }
 
 SENSORS_SCHEMA = cv.All({

--- a/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-climatecall.cpp
@@ -85,6 +85,28 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
   // HVane?
   // Swing?
 
+  if (call.get_swing_mode().has_value()) {
+    switch (call.get_swing_mode().value()) {
+      case climate::CLIMATE_SWING_OFF:
+        if (climate_traits_.supports_swing_mode(climate::CLIMATE_SWING_VERTICAL))
+          setRequestPacket.setVane(this->last_known_vane_position);
+
+        if (climate_traits_.supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL))
+          setRequestPacket.setHorizontalVane(this->last_known_hvane_position);
+        break;
+      case climate::CLIMATE_SWING_BOTH:
+        setRequestPacket.setHorizontalVane(SettingsSetRequestPacket::HV_SWING);
+        setRequestPacket.setVane(SettingsSetRequestPacket::VANE_SWING);
+        break;
+      case climate::CLIMATE_SWING_VERTICAL:
+        setRequestPacket.setVane(SettingsSetRequestPacket::VANE_SWING);
+        break;
+      case climate::CLIMATE_SWING_HORIZONTAL:
+        setRequestPacket.setHorizontalVane(SettingsSetRequestPacket::HV_SWING);
+        break;
+    }
+  }
+
   // We're assuming that every climate call *does* make some change worth sending to the heat pump
   // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
   hp_bridge.sendPacket(setRequestPacket);

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -48,7 +48,7 @@ void MitsubishiUART::processPacket(const ExtendedConnectResponsePacket &packet) 
   // Not sure if there's any needed content in this response, so assume we're connected.
   // TODO: Is there more useful info in these?
   hpConnected = true;
-  ESP_LOGI(TAG, "Heatpump connected.");
+  ESP_LOGI(TAG, "Received heat pump identification packet.");
 };
 
 void MitsubishiUART::processPacket(const GetRequestPacket &packet) {

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -48,6 +48,7 @@ void MitsubishiUART::processPacket(const ExtendedConnectResponsePacket &packet) 
   // Not sure if there's any needed content in this response, so assume we're connected.
   // TODO: Is there more useful info in these?
   hpConnected = true;
+  _capabilitiesCache = packet;
   ESP_LOGI(TAG, "Received heat pump identification packet.");
 };
 

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -124,7 +124,9 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
 
   // TODO: It would probably be nice to have the enum->string mapping defined somewhere to avoid typos/errors
   const std::string old_vane_position = vane_position_select->state;
-  switch(packet.getVane()) {
+  const auto vane_position = static_cast<SettingsSetRequestPacket::VANE_BYTE>(packet.getVane());
+  this->set_last_known_vane_position(vane_position);
+  switch(vane_position) {
     case SettingsSetRequestPacket::VANE_AUTO:
       vane_position_select->state = "Auto";
       break;
@@ -153,7 +155,9 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
 
 
   const std::string old_horizontal_vane_position = horizontal_vane_position_select->state;
-  switch(packet.getHorizontalVane()) {
+  const auto hvane_position = static_cast<SettingsSetRequestPacket::HORIZONTAL_VANE_BYTE>(packet.getHorizontalVane());
+  this->set_last_known_hvane_position(hvane_position);
+  switch(hvane_position) {
     case SettingsSetRequestPacket::HV_LEFT_FULL:
       horizontal_vane_position_select->state = "<<";
       break;

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -289,13 +289,29 @@ void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
   }
 
   //TODO: Not sure what AutoMode does yet
-};
+}
+
 void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   routePacket(packet);
-  // TODO: The MHK2 thermostat often asks for this, but the response is usually just all zeros.  Could be be checking for
-  // errors / messages / warnings.  Should check when e.g. the filter life runs out.
-};
+
+  auto oldErrorCode = error_code_sensor->raw_state;
+
+  // TODO: Include friendly text from JSON, somehow.
+  if (!packet.errorPresent()) {
+    error_code_sensor->raw_state = "No Error Reported";
+  } else if (packet.getRawShortCode() != 0x00) {
+    error_code_sensor->raw_state = "Error " + packet.getShortCode();
+  } else if (packet.getErrorCode() != 0x8000) {
+    error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
+  } else {
+    // Logic bug :(
+    ESP_LOGW(TAG, "Packet indicated an error was present, but none of the error states matched. wat.");
+  }
+
+  publishOnUpdate |= (oldErrorCode != error_code_sensor->state);
+}
+
 void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -284,8 +284,8 @@ void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
   }
 
   if (actual_fan_sensor) {
-    const uint8_t old_actual_fan = actual_fan_sensor->raw_state;
-    actual_fan_sensor->raw_state = packet.getActualFanSpeed();
+    const auto old_actual_fan = actual_fan_sensor->raw_state;
+    actual_fan_sensor->raw_state = ACTUAL_FAN_SPEED_NAMES[packet.getActualFanSpeed()];
     publishOnUpdate |= (old_actual_fan != actual_fan_sensor->raw_state);
   }
 

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -180,7 +180,7 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
       horizontal_vane_position_select->state = "Swing";
       break;
     default:
-      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.getVane());
+      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.getHorizontalVane());
   }
   publishOnUpdate |= (old_horizontal_vane_position != horizontal_vane_position_select->state);
 };

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -72,8 +72,19 @@ void MitsubishiUART::restore_preferences() {
     }
 }
 
-void MitsubishiUART::sendIfActive(const Packet& packet) {
-  if (active_mode) hp_bridge.sendPacket(packet);
+void MitsubishiUART::sendIfActive(const Packet &packet) {
+  if (active_mode)
+    hp_bridge.sendPacket(packet);
+}
+
+void MitsubishiUART::set_last_known_vane_position(SettingsSetRequestPacket::VANE_BYTE state) {
+  if (state == SettingsSetRequestPacket::VANE_SWING) return;
+  this->last_known_vane_position = state;
+}
+
+void MitsubishiUART::set_last_known_hvane_position(SettingsSetRequestPacket::HORIZONTAL_VANE_BYTE state) {
+  if (state == SettingsSetRequestPacket::HV_SWING) return;
+  this->last_known_hvane_position = state;
 }
 
 #define IFACTIVE(dothis) if (active_mode) {dothis}

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -118,8 +118,10 @@ be about `update_interval` late from their actual time.  Generally the update in
 (default is 5seconds) this won't pose a practical problem.
 */
 void MitsubishiUART::update() {
+  this->_updateLoopCounter += 1;
 
-  // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
+  // TODO: Temporarily wait 5 seconds on startup to help with viewing logs.
+  // TODO: Move all this into some setup step.
   if (millis() < 5000) {
     return;
   }
@@ -127,6 +129,12 @@ void MitsubishiUART::update() {
   // If we're not yet connected, send off a connection request (we'll check again next update)
   if (!hpConnected) {
     IFACTIVE(hp_bridge.sendPacket(ConnectRequestPacket::instance());)
+    return;
+  }
+
+  // Block until we get our extended capabilities information.
+  if (!_capabilitiesCache.has_value()) {
+    IFACTIVE(hp_bridge.sendPacket(ExtendedConnectRequestPacket::instance());)
     return;
   }
 
@@ -144,6 +152,11 @@ void MitsubishiUART::update() {
   hp_bridge.sendPacket(GetRequestPacket::getStatusInstance());
   hp_bridge.sendPacket(GetRequestPacket::getCurrentTempInstance());
   )
+
+  // TODO: get this every 60 seconds instead of every n loops
+  if (this->_updateLoopCounter % 10 == 0 && this->ts_bridge != nullptr) {
+    IFACTIVE(hp_bridge.sendPacket(GetRequestPacket::getErrorInfoInstance());)
+  }
 }
 
 void MitsubishiUART::doPublish() {

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -168,6 +168,10 @@ void MitsubishiUART::doPublish() {
     ESP_LOGI(TAG, "Actual fan speed differs, do publish");
     actual_fan_sensor->publish_state(actual_fan_sensor->raw_state);
   }
+  if (error_code_sensor && (error_code_sensor->raw_state != error_code_sensor->state)) {
+    ESP_LOGI(TAG, "Error code state differs, do publish");
+    error_code_sensor->publish_state(error_code_sensor->raw_state);
+  }
 
   // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change
   service_filter_sensor->publish_state(service_filter_sensor->state);

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -154,7 +154,7 @@ void MitsubishiUART::update() {
   )
 
   // TODO: get this every 60 seconds instead of every n loops
-  if (this->_updateLoopCounter % 10 == 0 && this->ts_bridge != nullptr) {
+  if (this->_updateLoopCounter % 10 == 0 && !ts_bridge) {
     IFACTIVE(hp_bridge.sendPacket(GetRequestPacket::getErrorInfoInstance());)
   }
 }

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -74,6 +74,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {defrost_sensor = sensor;};
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) {hot_adjust_sensor = sensor;};
   void set_standby_sensor(binary_sensor::BinarySensor *sensor) {standby_sensor = sensor;};
+  void set_error_code_sensor(text_sensor::TextSensor *sensor) { error_code_sensor = sensor; };
 
   // Select setters
   void set_temperature_source_select(select::Select *select) {temperature_source_select = select;};
@@ -155,6 +156,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     binary_sensor::BinarySensor *defrost_sensor = nullptr;
     binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;
     binary_sensor::BinarySensor *standby_sensor = nullptr;
+    text_sensor::TextSensor *error_code_sensor = nullptr;
 
     // Selects
     select::Select *temperature_source_select;

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -34,6 +34,11 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
    */
   MitsubishiUART(uart::UARTComponent *hp_uart_comp);
 
+  uint8_t compressor_frequency;
+
+  SettingsSetRequestPacket::VANE_BYTE last_known_vane_position = SettingsSetRequestPacket::VANE_AUTO;
+  SettingsSetRequestPacket::HORIZONTAL_VANE_BYTE last_known_hvane_position = SettingsSetRequestPacket::HV_CENTER;
+
   // Used to restore state of previous MUART-specific settings (like temperature source or pass-thru mode)
   // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
   void setup() override;
@@ -163,6 +168,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
     void sendIfActive(const Packet& packet);
     bool active_mode = true;
+
+    void set_last_known_vane_position(SettingsSetRequestPacket::VANE_BYTE state);
+    void set_last_known_hvane_position(SettingsSetRequestPacket::HORIZONTAL_VANE_BYTE state);
 };
 
 struct MUARTPreferences {

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -142,6 +142,11 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Should we call publish on the next update?
     bool publishOnUpdate = false;
 
+    optional<ExtendedConnectResponsePacket> _capabilitiesCache;
+
+    // used to track inconsistent updates
+    uint32_t _updateLoopCounter = 0;
+
     // Preferences
     void save_preferences();
     void restore_preferences();

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -27,6 +27,11 @@ const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000; // (7min) The heatpump wi
 
 const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
+// these names come from Kumo. They are bad, but I am also too lazy to think of better names. they also
+// may not map perfectly yet?
+const std::array<std::string, 7> ACTUAL_FAN_SPEED_NAMES = {"Off", "Very Low", "Quiet", "Low", "Powerful",
+                                                           "Super Powerful", "Super Quiet"};
+
 class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
  public:
   /**
@@ -69,7 +74,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Sensor setters
   void set_thermostat_temperature_sensor(sensor::Sensor *sensor) {thermostat_temperature_sensor = sensor;};
   void set_compressor_frequency_sensor(sensor::Sensor *sensor) {compressor_frequency_sensor = sensor;};
-  void set_actual_fan_sensor(sensor::Sensor *sensor) {actual_fan_sensor = sensor;};
+  void set_actual_fan_sensor(text_sensor::TextSensor *sensor) {actual_fan_sensor = sensor;};
   void set_service_filter_sensor(binary_sensor::BinarySensor *sensor) {service_filter_sensor = sensor;};
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {defrost_sensor = sensor;};
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) {hot_adjust_sensor = sensor;};
@@ -156,7 +161,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Internal sensors
     sensor::Sensor *thermostat_temperature_sensor = nullptr;
     sensor::Sensor *compressor_frequency_sensor = nullptr;
-    sensor::Sensor *actual_fan_sensor = nullptr;
+    text_sensor::TextSensor *actual_fan_sensor = nullptr;
     binary_sensor::BinarySensor *service_filter_sensor = nullptr;
     binary_sensor::BinarySensor *defrost_sensor = nullptr;
     binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;

--- a/components/mitsubishi_uart/muart_bridge.cpp
+++ b/components/mitsubishi_uart/muart_bridge.cpp
@@ -180,8 +180,8 @@ void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
       case SetCommand::settings :
         processRawPacket<SettingsSetRequestPacket>(pkt, true);
         break;
-      case SetCommand::a_7 :
-        processRawPacket<A7SetRequestPacket>(pkt, false);
+      case SetCommand::thermostat_hello :
+        processRawPacket<ThermostatHelloRequestPacket>(pkt, false);
         break;
       default:
         processRawPacket<Packet>(pkt, true);

--- a/components/mitsubishi_uart/muart_bridge.cpp
+++ b/components/mitsubishi_uart/muart_bridge.cpp
@@ -156,7 +156,7 @@ void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
       case GetCommand::current_temp :
         processRawPacket<CurrentTempGetResponsePacket>(pkt, false);
         break;
-      case GetCommand::four :
+      case GetCommand::error_info :
         processRawPacket<ErrorStateGetResponsePacket>(pkt, false);
         break;
       case GetCommand::standby :

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -199,8 +199,8 @@ climate::ClimateTraits ExtendedConnectResponsePacket::asTraits() const {
   if (this->supportsHVaneSwing())
     ct.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
 
-  ct.set_visual_min_temperature(min(this->getMinCoolDrySetpoint(), this->getMinHeatingSetpoint()));
-  ct.set_visual_max_temperature(max(this->getMaxCoolDrySetpoint(), this->getMaxHeatingSetpoint()));
+  ct.set_visual_min_temperature(std::min(this->getMinCoolDrySetpoint(), this->getMinHeatingSetpoint()));
+  ct.set_visual_max_temperature(std::max(this->getMaxCoolDrySetpoint(), this->getMaxHeatingSetpoint()));
 
   // TODO: Figure out what these states *actually* map to so we aren't sending bad data.
   // This is probably a dynamic map, so the setter will need to be aware of things.

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -61,8 +61,9 @@ std::string StatusGetResponsePacket::to_string() const {
 }
 std::string ErrorStateGetResponsePacket::to_string() const {
   return ("Error State Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
-          "\n ErrorCode: " + format_hex(getErrorCode()) +
-          " ShortCode: " + getShortCode() + "(" + format_hex(getRawShortCode()) + ")");
+          "\n Error State: " + (errorPresent() ? "Yes" : "No")
+          + " ErrorCode: " + format_hex(getErrorCode()) +
+          " ShortCode: " + getShortCode() + " (" + format_hex(getRawShortCode()) + ")");
 }
 std::string RemoteTemperatureSetRequestPacket::to_string() const {
   return ("Remote Temp Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
@@ -122,10 +123,10 @@ float SettingsGetResponsePacket::getTargetTemp() const {
 
   if (enhancedTemperature == 0x00) {
     auto legacyTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
-    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)legacyTemperature / 0x10));
+    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)(legacyTemperature & 0x10)));
   }
 
-  return ((float) pkt_.getPayloadByte(PLINDEX_TARGETTEMP) - 128) / 2.0f;
+  return ((float)enhancedTemperature - 128) / 2.0f;
 }
 
 

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -53,7 +53,7 @@ std::string StandbyGetResponsePacket::to_string() const {
           " Defrost:" + (inDefrost() ? "Yes" : "No") +
           " HotAdjust:" + (inHotAdjust() ? "Yes" : "No") +
           " Standby:" + (inStandby() ? "Yes" : "No") +
-          " ActualFan:" + std::to_string(getActualFanSpeed()) +
+          " ActualFan:" + ACTUAL_FAN_SPEED_NAMES[getActualFanSpeed()] + " (" + std::to_string(getActualFanSpeed()) + ")" +
           " AutoMode:" + format_hex(getAutoMode());
 }
 std::string StatusGetResponsePacket::to_string() const {

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -6,96 +6,77 @@ namespace mitsubishi_uart {
 // Packet to_strings()
 
 std::string ConnectRequestPacket::to_string() const {
-  return("Connect Request: " + Packet::to_string());
+  return "Connect Request: " + Packet::to_string();
 }
 std::string ConnectResponsePacket::to_string() const {
-  return("Connect Response: " + Packet::to_string());
+  return "Connect Response: " + Packet::to_string();
 }
 std::string ExtendedConnectResponsePacket::to_string() const {
-  return ("Extended Connect Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n HeatDisabled:" + (isHeatDisabled()?"Yes":"No")
-  + " SupportsVane:" + (supportsVane()?"Yes":"No")
-  + " SupportsVaneSwing:" + (supportsVaneSwing()?"Yes":"No")
-
-  + " DryDisabled:" + (isDryDisabled()?"Yes":"No")
-  + " FanDisabled:" + (isFanDisabled()?"Yes":"No")
-  + " ExtTempRange:" + (hasExtendedTemperatureRange()?"Yes":"No")
-  + " AutoFan:" + (hasAutoFanSpeed()?"Yes":"No")
-  + " InstallerSettings:" + (supportsInstallerSettings()?"Yes":"No")
-  + " TestMode:" + (supportsTestMode()?"Yes":"No")
-  + " DryTemp:" + (supportsDryTemperature()?"Yes":"No")
-
-  + " StatusDisplay:" + (hasStatusDisplay()?"Yes":"No")
-
-  + "\n CoolDrySetpoint:" + std::to_string(getMinCoolDrySetpoint()) + "/" + std::to_string(getMaxCoolDrySetpoint())
-  + " HeatSetpoint:" + std::to_string(getMinHeatingSetpoint()) + "/" + std::to_string(getMaxHeatingSetpoint())
-  + " AutoSetpoint:" + std::to_string(getMinAutoSetpoint()) + "/" + std::to_string(getMaxAutoSetpoint())
-  + " FanSpeeds:" + std::to_string(getSupportedFanSpeeds()));
+  return "Extended Connect Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+           "\n HeatDisabled:" + (isHeatDisabled() ? "Yes" : "No") +
+           " SupportsVane:" + (supportsVane() ? "Yes" : "No") +
+           " SupportsVaneSwing:" + (supportsVaneSwing() ? "Yes" : "No") +
+           " DryDisabled:" + (isDryDisabled() ? "Yes" : "No") +
+           " FanDisabled:" + (isFanDisabled() ? "Yes" : "No") +
+           " ExtTempRange:" + (hasExtendedTemperatureRange() ? "Yes" : "No") +
+           " AutoFanDisabled:" + (autoFanSpeedDisabled() ? "Yes" : "No") +
+           " InstallerSettings:" + (supportsInstallerSettings() ? "Yes" : "No") +
+           " TestMode:" + (supportsTestMode() ? "Yes" : "No") +
+           " DryTemp:" + (supportsDryTemperature() ? "Yes" : "No") +
+           " StatusDisplay:" + (hasStatusDisplay() ? "Yes" : "No") +
+           "\n CoolDrySetpoint:" + std::to_string(getMinCoolDrySetpoint()) + "/" + std::to_string(getMaxCoolDrySetpoint()) +
+           " HeatSetpoint:" + std::to_string(getMinHeatingSetpoint()) + "/" + std::to_string(getMaxHeatingSetpoint()) +
+           " AutoSetpoint:" + std::to_string(getMinAutoSetpoint()) + "/" + std::to_string(getMaxAutoSetpoint()) +
+           " FanSpeeds:" + std::to_string(getSupportedFanSpeeds());
 }
 std::string CurrentTempGetResponsePacket::to_string() const {
-  return ("Current Temp Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n Temp:" + std::to_string(getCurrentTemp()));
+  return "Current Temp Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Temp:" + std::to_string(getCurrentTemp());
 }
 std::string SettingsGetResponsePacket::to_string() const {
+  return "Settings Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE + "\n Fan:" + format_hex(getFan()) +
+          " Mode:" + format_hex(getMode()) +
+          " Power:" + (getPower() == 3  ? "Test" : getPower() > 0 ? "On" : "Off") +
+          " TargetTemp:" + std::to_string(getTargetTemp()) +
+          " Vane:" + format_hex(getVane()) +
+          " HVane:" + format_hex(getHorizontalVane()) +
 
-  return ("Settings Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n Fan:" + format_hex(getFan())
-  + " Mode:" + format_hex(getMode())
-  + " Power:" + (getPower()==3 ? "Test" : getPower()>0 ? "On" : "Off")
-  + " TargetTemp:" + std::to_string(getTargetTemp())
-  + " Vane:" + format_hex(getVane())
-  + " HVane:" + format_hex(getHorizontalVane())
-  + "\n PowerLock:" + (lockedPower()?"Yes":"No")
-  + " ModeLock:" + (lockedMode()?"Yes":"No")
-  + " TempLock:" + (lockedTemp()?"Yes":"No")
-  );
+          "\n PowerLock:" + (lockedPower() ? "Yes" : "No") +
+          " ModeLock:" + (lockedMode() ? "Yes" : "No") +
+          " TempLock:" + (lockedTemp() ? "Yes" : "No");
 }
 std::string StandbyGetResponsePacket::to_string() const {
-  return ("Standby Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n ServiceFilter:" + (serviceFilter()?"Yes":"No")
-  + " Defrost:" + (inDefrost()?"Yes":"No")
-  + " HotAdjust:" + (inHotAdjust()?"Yes":"No")
-  + " Standby:" + (inStandby()?"Yes":"No")
-  + " ActualFan:" + std::to_string(getActualFanSpeed())
-  + " AutoMode:" + format_hex(getAutoMode())
-  );
+  return "Standby Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n ServiceFilter:" + (serviceFilter() ? "Yes" : "No") +
+          " Defrost:" + (inDefrost() ? "Yes" : "No") +
+          " HotAdjust:" + (inHotAdjust() ? "Yes" : "No") +
+          " Standby:" + (inStandby() ? "Yes" : "No") +
+          " ActualFan:" + std::to_string(getActualFanSpeed()) +
+          " AutoMode:" + format_hex(getAutoMode());
 }
 std::string StatusGetResponsePacket::to_string() const {
-  return ("Status Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n CompressorFrequency: " + std::to_string(getCompressorFrequency())
-  + " Operating: " + (getOperating() ? "Yes":"No")
-  );
+  return "Status Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n CompressorFrequency: " + std::to_string(getCompressorFrequency()) +
+          " Operating: " + (getOperating() ? "Yes" : "No");
 }
 std::string ErrorStateGetResponsePacket::to_string() const {
-  return ("Error State Response: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n ErrorCode: " + format_hex(getErrorCode())
-  + " ShortCode: " + format_hex(getShortCode()) // TODO: This can be converted to a code string
+  return ("Error State Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n ErrorCode: " + format_hex(getErrorCode()) +
+          " ShortCode: " + format_hex(getShortCode())  // TODO: This can be converted to a code string
   );
 }
 std::string RemoteTemperatureSetRequestPacket::to_string() const {
-  return ("Remote Temp Set Request: " + Packet::to_string()
-  + CONSOLE_COLOR_PURPLE
-  + "\n Temp:" + std::to_string(getRemoteTemperature()));
+  return ("Remote Temp Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Temp:" + std::to_string(getRemoteTemperature()));
 }
-
 
 // TODO: Are there function implementations for packets in the .h file? (Yes)  Should they be here?
 
 // SettingsSetRequestPacket functions
 
-void SettingsSetRequestPacket::addSettingsFlag(const SETTING_FLAG flagToAdd) {
-  addFlag(flagToAdd);
-}
+void SettingsSetRequestPacket::addSettingsFlag(const SETTING_FLAG flagToAdd) { addFlag(flagToAdd); }
 
-void SettingsSetRequestPacket::addSettingsFlag2(const SETTING_FLAG2 flag2ToAdd) {
-  addFlag2(flag2ToAdd);
-}
+void SettingsSetRequestPacket::addSettingsFlag2(const SETTING_FLAG2 flag2ToAdd) { addFlag2(flag2ToAdd); }
 
 SettingsSetRequestPacket &SettingsSetRequestPacket::setPower(const bool isOn) {
   pkt_.setPayloadByte(PLINDEX_POWER, isOn ? 0x01 : 0x00);
@@ -136,13 +117,12 @@ SettingsSetRequestPacket &SettingsSetRequestPacket::setHorizontalVane(const HORI
   return *this;
 }
 
-
 // RemoteTemperatureSetRequestPacket functions
 
 RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::setRemoteTemperature(float temperatureDegressC) {
   if (temperatureDegressC < 63.5 && temperatureDegressC > -64.0) {
     pkt_.setPayloadByte(PLINDEX_REMOTE_TEMPERATURE, round(temperatureDegressC * 2) + 128);
-    setFlags(0x01); // Set flags to say we're providing the temperature
+    setFlags(0x01);  // Set flags to say we're providing the temperature
   } else {
     ESP_LOGW(PTAG, "Remote temp %f is outside valid range.", temperatureDegressC);
   }
@@ -151,6 +131,93 @@ RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::setRemoteT
 RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::useInternalTemperature() {
   setFlags(0x00);  // Set flags to say to use internal temperature
   return *this;
+}
+
+// ExtendedConnectResponsePacket functions
+uint8_t ExtendedConnectResponsePacket::getSupportedFanSpeeds() const {
+  uint8_t raw_value = ((pkt_.getPayloadByte(7) & 0x10) >> 2) + ((pkt_.getPayloadByte(8) & 0x08) >> 2) +
+                      ((pkt_.getPayloadByte(9) & 0x02) >> 1);
+
+  switch (raw_value) {
+    case 1:
+    case 2:
+    case 4:
+      return raw_value;
+    case 0:
+      return 3;
+    case 6:
+      return 5;
+
+    default:
+      ESP_LOGW(PACKETS_TAG, "Unexpected supported fan speeds: %i", raw_value);
+      return 0;  // TODO: Depending on how this is used, it might be more useful to just return 3 and hope for the best
+  }
+}
+
+climate::ClimateTraits ExtendedConnectResponsePacket::asTraits() const {
+  auto ct = climate::ClimateTraits();
+
+  // always enabled
+  ct.add_supported_mode(climate::CLIMATE_MODE_COOL);
+  ct.add_supported_mode(climate::CLIMATE_MODE_OFF);
+
+  if (!this->isHeatDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_HEAT);
+  if (!this->isDryDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_DRY);
+  if (!this->isFanDisabled())
+    ct.add_supported_mode(climate::CLIMATE_MODE_FAN_ONLY);
+
+  if (this->supportsVaneSwing() && this->supportsHVaneSwing())
+    ct.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
+  if (this->supportsVaneSwing())
+    ct.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
+  if (this->supportsHVaneSwing())
+    ct.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+
+  ct.set_visual_min_temperature(min(this->getMinCoolDrySetpoint(), this->getMinHeatingSetpoint()));
+  ct.set_visual_max_temperature(max(this->getMaxCoolDrySetpoint(), this->getMaxHeatingSetpoint()));
+
+  // TODO: Figure out what these states *actually* map to so we aren't sending bad data.
+  // This is probably a dynamic map, so the setter will need to be aware of things.
+  switch (this->getSupportedFanSpeeds()) {
+    case 1:
+      ct.set_supported_fan_modes({climate::CLIMATE_FAN_HIGH});
+      break;
+    case 2:
+      ct.set_supported_fan_modes({climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_HIGH});
+      break;
+    case 3:
+      ct.set_supported_fan_modes({
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH
+      });
+      break;
+    case 4:
+      ct.set_supported_fan_modes({
+          climate::CLIMATE_FAN_QUIET,
+          climate::CLIMATE_FAN_LOW,
+          climate::CLIMATE_FAN_MEDIUM,
+          climate::CLIMATE_FAN_HIGH,
+      });
+      break;
+    case 5:
+      ct.set_supported_fan_modes({
+          climate::CLIMATE_FAN_QUIET,
+          climate::CLIMATE_FAN_LOW,
+          climate::CLIMATE_FAN_MEDIUM,
+          climate::CLIMATE_FAN_HIGH,
+      });
+      ct.add_supported_custom_fan_mode("Very High");
+      break;
+    default:
+      // no-op, don't set a fan mode.
+      break;
+  }
+  if (!this->autoFanSpeedDisabled()) ct.add_supported_fan_mode(climate::CLIMATE_FAN_AUTO);
+
+  return ct;
 }
 
 }  // namespace mitsubishi_uart

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -62,8 +62,7 @@ std::string StatusGetResponsePacket::to_string() const {
 std::string ErrorStateGetResponsePacket::to_string() const {
   return ("Error State Response: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
           "\n ErrorCode: " + format_hex(getErrorCode()) +
-          " ShortCode: " + format_hex(getShortCode())  // TODO: This can be converted to a code string
-  );
+          " ShortCode: " + getShortCode() + "(" + format_hex(getRawShortCode()) + ")");
 }
 std::string RemoteTemperatureSetRequestPacket::to_string() const {
   return ("Remote Temp Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
@@ -219,6 +218,24 @@ climate::ClimateTraits ExtendedConnectResponsePacket::asTraits() const {
 
   return ct;
 }
+
+// ErrorStateGetResponsePacket functions
+std::string ErrorStateGetResponsePacket::getShortCode() const {
+  const auto upperAlphabet = "AbEFJLPU";
+  const auto lowerAlphabet = "0123456789ABCDEFOHJLPU";
+  const auto errorCode = this->getRawShortCode();
+
+  auto lowBits = errorCode & 0x1F;
+  if (lowBits > 0x15) {
+    ESP_LOGW(PACKETS_TAG, "Error lowbits %x were out of range.", lowBits);
+    char buf[7];
+    sprintf(buf, "ERR_%x", errorCode);
+    return buf;
+  }
+
+  return {upperAlphabet[(errorCode & 0xE0) >> 5], lowerAlphabet[lowBits]};
+}
+
 
 }  // namespace mitsubishi_uart
 }  // namespace esphome

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -1,5 +1,6 @@
 #include "muart_packet.h"
 #include "mitsubishi_uart.h"
+#include "muart_utils.h"
 
 namespace esphome {
 namespace mitsubishi_uart {
@@ -69,6 +70,12 @@ std::string ErrorStateGetResponsePacket::to_string() const {
 std::string RemoteTemperatureSetRequestPacket::to_string() const {
   return ("Remote Temp Set Request: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
           "\n Temp:" + std::to_string(getRemoteTemperature()));
+}
+std::string ThermostatHelloRequestPacket::to_string() const {
+  return("Thermostat Hello: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Model: " + getThermostatModel() +
+          " Serial: " + getThermostatSerial() +
+          " Version: " + getThermostatVersionString());
 }
 
 // TODO: Are there function implementations for packets in the .h file? (Yes)  Should they be here?
@@ -262,6 +269,20 @@ std::string ErrorStateGetResponsePacket::getShortCode() const {
   return {upperAlphabet[(errorCode & 0xE0) >> 5], lowerAlphabet[lowBits]};
 }
 
+// ThermostatHelloRequestPacket functions
+std::string ThermostatHelloRequestPacket::getThermostatModel() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 1), 3, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatSerial() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 4), 8, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatVersionString() const {
+  char buf[16];
+  sprintf(buf, "%02d.%02d.%02d", pkt_.getPayloadByte(13), pkt_.getPayloadByte(14), pkt_.getPayloadByte(15));
+  return buf;
+}
 
 }  // namespace mitsubishi_uart
 }  // namespace esphome

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -97,9 +97,8 @@ class ExtendedConnectRequestPacket : public Packet {
   }
   using Packet::Packet;
  private:
-  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::extended_connect_request, 2)) {
-    pkt_.setPayloadByte(0, 0xca);
-    pkt_.setPayloadByte(1, 0x01);
+  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::extended_connect_request, 1)) {
+    pkt_.setPayloadByte(0, 0xc9);
   }
 };
 

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -31,7 +31,7 @@ class Packet {
 
     // Is a response packet expected when this packet is sent.  Defaults to true since
     // most requests receive a response.
-    const bool isResponseExpected() const {return responseExpected;};
+    bool isResponseExpected() const {return responseExpected;};
     void setResponseExpected(bool expectResponse) {responseExpected = expectResponse;};
 
     // Passthrough methods to RawPacket

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -356,12 +356,18 @@ public:
 };
 
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
-class A7SetRequestPacket : public Packet {
+class ThermostatHelloRequestPacket : public Packet {
   using Packet::Packet;
  public:
-  A7SetRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
-    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::a_7));
+  ThermostatHelloRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::thermostat_hello));
   }
+
+  std::string getThermostatModel() const;
+  std::string getThermostatSerial() const;
+  std::string getThermostatVersionString() const;
+
+  std::string to_string() const override;
 };
 
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -135,7 +135,7 @@ class ExtendedConnectResponsePacket : public Packet {
   // Things that have to exist, but we don't know where yet.
   bool supportsHVaneSwing() const { return false; }
 
-  // Fan Speeds TODO: Probably move this to .cpp?
+  // Fan Speeds
   uint8_t getSupportedFanSpeeds() const;
 
   // Convert a temperature response into ClimateTraits. This will *not* include library-provided features.
@@ -177,6 +177,7 @@ class GetRequestPacket : public Packet {
 class SettingsGetResponsePacket : public Packet {
   static const int PLINDEX_POWER = 3;
   static const int PLINDEX_MODE = 4;
+  static const int PLINDEX_TARGETTEMP_LEGACY = 5;
   static const int PLINDEX_FAN = 6;
   static const int PLINDEX_VANE = 7;
   static const int PLINDEX_PROHIBITFLAGS = 8;
@@ -193,7 +194,8 @@ class SettingsGetResponsePacket : public Packet {
   bool lockedMode() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x02; }
   bool lockedTemp() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x04; }
   uint8_t getHorizontalVane() const { return pkt_.getPayloadByte(PLINDEX_HVANE); }
-  float getTargetTemp() const { return ((int) pkt_.getPayloadByte(PLINDEX_TARGETTEMP) - 128) / 2.0f; }
+
+  float getTargetTemp() const;
 
   std::string to_string() const override;
 };
@@ -204,7 +206,7 @@ class CurrentTempGetResponsePacket : public Packet {
   using Packet::Packet;
 
  public:
-  float getCurrentTemp() const { return ((int) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP) - 128) / 2.0f; }
+  float getCurrentTemp() const;
   std::string to_string() const override;
 };
 

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -241,7 +241,10 @@ class ErrorStateGetResponsePacket : public Packet {
   using Packet::Packet;
  public:
   uint16_t getErrorCode() const {return pkt_.getPayloadByte(4) << 8 | pkt_.getPayloadByte(5);}
-  uint8_t getShortCode() const {return pkt_.getPayloadByte(6);}
+  uint8_t getRawShortCode() const {return pkt_.getPayloadByte(6);}
+  std::string getShortCode() const;
+
+  bool errorPresent() const { return getErrorCode() == 0x8000 && getRawShortCode() == 0x00; }
 
   std::string to_string() const override;
 };

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -166,6 +166,10 @@ class GetRequestPacket : public Packet {
     static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::status);
     return INSTANCE;
   }
+  static GetRequestPacket& getErrorInfoInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::error_info);
+    return INSTANCE;
+  }
   using Packet::Packet;
 
  private:

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -246,7 +246,7 @@ class ErrorStateGetResponsePacket : public Packet {
   uint8_t getRawShortCode() const {return pkt_.getPayloadByte(6);}
   std::string getShortCode() const;
 
-  bool errorPresent() const { return getErrorCode() == 0x8000 && getRawShortCode() == 0x00; }
+  bool errorPresent() const { return getErrorCode() != 0x8000 || getRawShortCode() != 0x00; }
 
   std::string to_string() const override;
 };

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -43,7 +43,7 @@ enum class GetCommand : uint8_t {
 enum class SetCommand : uint8_t {
   settings = 0x01,
   remote_temperature = 0x07,
-  a_7 = 0xa7
+  thermostat_hello = 0xa7
 };
 
 // Which MUARTBridge was the packet read from (used to determine flow direction of the packet)

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -80,7 +80,7 @@ class RawPacket {
 
   virtual std::string to_string() const {return format_hex_pretty(&getBytes()[0], getLength());};
 
-  const uint8_t getLength() const { return length; };
+  uint8_t getLength() const { return length; };
   const uint8_t *getBytes() const { return packetBytes; };  // Primarily for sending packets
 
   bool isChecksumValid() const;

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -33,7 +33,7 @@ enum class PacketType : uint8_t {
 enum class GetCommand : uint8_t {
   settings = 0x02,
   current_temp = 0x03,
-  four = 0x04,
+  error_info = 0x04,
   status = 0x06,
   standby = 0x09,
   a_9 = 0xa9

--- a/components/mitsubishi_uart/muart_utils.h
+++ b/components/mitsubishi_uart/muart_utils.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTUtils {
+ public:
+  static std::string DecodeNBitString(const uint8_t data[], size_t dataLength, size_t wordSize) {
+    auto resultLength = (dataLength / wordSize) + (dataLength % wordSize != 0);
+    auto result = std::string();
+
+    for (int i = 0; i < resultLength; i++) {
+      auto bits = BitSlice(data, i * wordSize, ((i + 1) * wordSize) - 1);
+      if (bits <= 0x1F) bits += 0x40;
+      result += (char)bits;
+    }
+
+    return result;
+  }
+
+ private:
+  static uint64_t BitSlice(const uint8_t ds[], size_t start, size_t end) {
+    // Lazies! https://stackoverflow.com/a/25297870/1817097
+    uint64_t s = 0;
+    size_t i, n = (end - 1) / 8;
+    for(i = 0; i <= n; ++i)
+      s = (s << 8) + ds[i];
+    s >>= (n+1) * 8 - end;
+    uint64_t mask = (((uint64_t)1) << (end - start + 1))-1;//len = end - start + 1
+    s &= mask;
+    return s;
+  }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,30 @@
+[MASTER]
+reports=no
+ignore=api_pb2.py
+
+disable=
+  format,
+  missing-docstring,
+  fixme,
+  unused-argument,
+  global-statement,
+  too-few-public-methods,
+  too-many-lines,
+  too-many-locals,
+  too-many-ancestors,
+  too-many-branches,
+  too-many-statements,
+  too-many-arguments,
+  too-many-return-statements,
+  too-many-instance-attributes,
+  duplicate-code,
+  invalid-name,
+  cyclic-import,
+  redefined-builtin,
+  undefined-loop-variable,
+  useless-object-inheritance,
+  stop-iteration-return,
+  import-outside-toplevel,
+  # Broken
+  unsupported-membership-test,
+  unsubscriptable-object,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[flake8]
+max-line-length = 120
+# Following 4 for black compatibility
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+
+# TODO fix flake8
+# D100 Missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+# D105 Missing docstring in magic method
+# D107 Missing docstring in __init__
+# D200 One-line docstring should fit on one line with quotes
+# D205 1 blank line required between summary line and description
+# D209 Multi-line docstring closing quotes should be on a separate line
+# D400 First line should end with a period
+# D401 First line should be in imperative mood
+
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+
+    D100,
+    D101,
+    D102,
+    D103,
+    D104,
+    D105,
+    D107,
+    D200,
+    D205,
+    D209,
+    D400,
+    D401,


### PR DESCRIPTION
woo, first "big" PR containing things of various quality. Keeping this as draft for a little bit as I play with things.

- Add the framework for climate card swing control
  - **NOT CURRENTLY WIRED IN.** Just skeleton things for now!
  - Track the last known non-swing vane state.
  - Upon deactivating swing mode on the climate card, switch back to the last-known mode, or auto/middle if no logged mode.
  - Starts work on #13.
- Add a text sensor for error information
  - Error state is read every ~10 update cycles if no UART thermostat is connected.
  - Implement Mitsubishi's two-character error code converter
  - Resolves #16, mostly.
- Start working on auto-capabilities framework
  - Add code to convert the ExtendedConnectResponse to traits
  - Request ExtendedConnectResponse as part of app boot
  - Fix this packet being in the wrong format
  - Starts work on #12.
- Suppress some warnings when using esp-idf builds
- Use legacy temperatures for state information if "modern" temperatures don't exist
- Fix horizontal vane log message showing the wrong vane information.
- Add *experimental* logging for ThermostatHello packets
  - Of course, now my thermostat doesnt spam my logs anymore. Ugh.
- Converts the Actual Fan Speed sensor to text, since the numeric values have no semantic meaning.
- Includes Actual Fan Speed names in the log for sanity purposes.