### PR TITLE
feat: Add error code sensor

### DIFF
--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, uart, sensor, binary_sensor, select, switch
+from esphome.components import climate, uart, sensor, binary_sensor, text_sensor, select, switch
 from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
@@ -19,14 +19,15 @@ from esphome.const import (
 )
 from esphome.core import coroutine
 
-AUTO_LOAD = ["climate", "select", "sensor", "binary_sensor", "switch"]
-DEPENDENCIES = ["uart", "climate", "sensor", "binary_sensor", "select", "switch"]
+AUTO_LOAD = ["climate", "select", "sensor", "binary_sensor", "text_sensor", "switch"]
+DEPENDENCIES = ["uart", "climate", "sensor", "binary_sensor", "text_sensor", "select", "switch"]
 
 CONF_HP_UART = "heatpump_uart"
 CONF_TS_UART = "thermostat_uart"
 
 CONF_SENSORS = "sensors"
 CONF_SENSORS_THERMOSTAT_TEMP = "thermostat_temperature"
+CONF_SENSORS_ERROR_CODE = "error_code"
 
 CONF_SELECTS = "selects"
 CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select" # This is to create a Select object for selecting a source
@@ -125,6 +126,11 @@ SENSORS = {
         binary_sensor.binary_sensor_schema(),
         binary_sensor.register_binary_sensor
     ),
+    CONF_SENSORS_ERROR_CODE: (
+        "Error Code",
+        text_sensor.text_sensor_schema(),
+        text_sensor.register_text_sensor
+    )
 }
 
 SENSORS_SCHEMA = cv.All({

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -285,13 +285,29 @@ void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
   }
 
   //TODO: Not sure what AutoMode does yet
-};
+}
+
 void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   routePacket(packet);
-  // TODO: The MHK2 thermostat often asks for this, but the response is usually just all zeros.  Could be be checking for
-  // errors / messages / warnings.  Should check when e.g. the filter life runs out.
-};
+
+  auto oldErrorCode = error_code_sensor->raw_state;
+
+  // TODO: Include friendly text from JSON, somehow.
+  if (!packet.errorPresent()) {
+    error_code_sensor->raw_state = "No Error Reported";
+  } else if (packet.getRawShortCode() != 0x00) {
+    error_code_sensor->raw_state = "Error " + packet.getShortCode();
+  } else if (packet.getErrorCode() != 0x8000) {
+    error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
+  } else {
+    // Logic bug :(
+    ESP_LOGW(TAG, "Packet indicated an error was present, but none of the error states matched. wat.");
+  }
+
+  publishOnUpdate |= (oldErrorCode != error_code_sensor->state);
+}
+
 void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -291,7 +291,7 @@ void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   routePacket(packet);
 
-  auto oldErrorCode = error_code_sensor->raw_state;
+  std::string oldErrorCode = error_code_sensor->raw_state;
 
   // TODO: Include friendly text from JSON, somehow.
   if (!packet.errorPresent()) {
@@ -303,14 +303,11 @@ void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
     }
 
     error_code_sensor->raw_state = "Error " + packet.getShortCode();
-  } else if (packet.getErrorCode() != 0x8000) {
-    error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
   } else {
-    // Logic bug, should never happen.
-    ESP_LOGW(TAG, "Packet indicated an error was present, but none of the error states matched. wat.");
+    error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
   }
 
-  publishOnUpdate |= (oldErrorCode != error_code_sensor->state);
+  publishOnUpdate |= (oldErrorCode != error_code_sensor->raw_state);
 }
 
 void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &packet) {

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -296,12 +296,17 @@ void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
   // TODO: Include friendly text from JSON, somehow.
   if (!packet.errorPresent()) {
     error_code_sensor->raw_state = "No Error Reported";
-  } else if (packet.getRawShortCode() != 0x00) {
+  } else if (auto rawCode = packet.getRawShortCode() != 0x00) {
+    // Not that it matters, but good for validation I guess.
+    if ((rawCode & 0x1F) > 0x15) {
+      ESP_LOGW(TAG, "Error short code %x had invalid low bits. This is an IT protocol violation!", rawCode);
+    }
+
     error_code_sensor->raw_state = "Error " + packet.getShortCode();
   } else if (packet.getErrorCode() != 0x8000) {
     error_code_sensor->raw_state = "Error " + to_string(packet.getErrorCode());
   } else {
-    // Logic bug :(
+    // Logic bug, should never happen.
     ESP_LOGW(TAG, "Packet indicated an error was present, but none of the error states matched. wat.");
   }
 

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -107,7 +107,8 @@ be about `update_interval` late from their actual time.  Generally the update in
 (default is 5seconds) this won't pose a practical problem.
 */
 void MitsubishiUART::update() {
-  this->_updateLoopCounter += 1;
+  // increment our update loop counter, and reset at 10,000 just to prevent overflow UB
+  if (++this->_updateLoopCounter >= 10000) this->_updateLoopCounter = 0;
 
   // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
   if (millis() < 5000) {

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -136,7 +136,7 @@ void MitsubishiUART::update() {
   )
 
   // TODO: get this every 60 seconds instead of every n loops
-  if (this->_updateLoopCounter % 10 == 0 && this->ts_bridge != nullptr) {
+  if (this->_updateLoopCounter % 10 == 0 && !ts_bridge) {
     IFACTIVE(hp_bridge.sendPacket(GetRequestPacket::getErrorInfoInstance());)
   }
 }

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -163,6 +163,10 @@ void MitsubishiUART::doPublish() {
     ESP_LOGI(TAG, "Actual fan speed differs, do publish");
     actual_fan_sensor->publish_state(actual_fan_sensor->raw_state);
   }
+  if (error_code_sensor && (error_code_sensor->raw_state != error_code_sensor->state)) {
+    ESP_LOGI(TAG, "Error code state differs, do publish");
+    error_code_sensor->publish_state(error_code_sensor->raw_state);
+  }
 
   // Binary sensors automatically dedup publishes (I think) and so will only actually publish on change
   service_filter_sensor->publish_state(service_filter_sensor->state);

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -107,6 +107,7 @@ be about `update_interval` late from their actual time.  Generally the update in
 (default is 5seconds) this won't pose a practical problem.
 */
 void MitsubishiUART::update() {
+  this->_updateLoopCounter += 1;
 
   // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
   if (millis() < 5000) {
@@ -133,6 +134,11 @@ void MitsubishiUART::update() {
   hp_bridge.sendPacket(GetRequestPacket::getStatusInstance());
   hp_bridge.sendPacket(GetRequestPacket::getCurrentTempInstance());
   )
+
+  // TODO: get this every 60 seconds instead of every n loops
+  if (this->_updateLoopCounter % 10 == 0 && this->ts_bridge != nullptr) {
+    IFACTIVE(hp_bridge.sendPacket(GetRequestPacket::getErrorInfoInstance());)
+  }
 }
 
 void MitsubishiUART::doPublish() {

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -137,9 +137,6 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Should we call publish on the next update?
     bool publishOnUpdate = false;
 
-    // used to track inconsistent updates
-    uint32_t _updateLoopCounter = 0;
-
     // Preferences
     void save_preferences();
     void restore_preferences();

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -69,6 +69,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {defrost_sensor = sensor;};
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) {hot_adjust_sensor = sensor;};
   void set_standby_sensor(binary_sensor::BinarySensor *sensor) {standby_sensor = sensor;};
+  void set_error_code_sensor(text_sensor::TextSensor *sensor) { error_code_sensor = sensor; };
 
   // Select setters
   void set_temperature_source_select(select::Select *select) {temperature_source_select = select;};
@@ -153,6 +154,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     binary_sensor::BinarySensor *defrost_sensor = nullptr;
     binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;
     binary_sensor::BinarySensor *standby_sensor = nullptr;
+    text_sensor::TextSensor *error_code_sensor = nullptr;
 
     // Selects
     select::Select *temperature_source_select;

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -136,6 +136,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Should we call publish on the next update?
     bool publishOnUpdate = false;
 
+    // used to track inconsistent updates
+    uint32_t _updateLoopCounter = 0;
+
     // Preferences
     void save_preferences();
     void restore_preferences();

--- a/components/mitsubishi_uart/muart_bridge.cpp
+++ b/components/mitsubishi_uart/muart_bridge.cpp
@@ -156,7 +156,7 @@ void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
       case GetCommand::current_temp :
         processRawPacket<CurrentTempGetResponsePacket>(pkt, false);
         break;
-      case GetCommand::four :
+      case GetCommand::error_info :
         processRawPacket<ErrorStateGetResponsePacket>(pkt, false);
         break;
       case GetCommand::standby :

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -1,5 +1,6 @@
 #include "muart_packet.h"
 #include "muart_utils.h"
+#include "mitsubishi_uart.h"
 
 namespace esphome {
 namespace mitsubishi_uart {
@@ -75,7 +76,8 @@ std::string StatusGetResponsePacket::to_string() const {
 std::string ErrorStateGetResponsePacket::to_string() const {
   return ("Error State Response: " + Packet::to_string()
   + CONSOLE_COLOR_PURPLE
-  + "\n ErrorCode: " + format_hex(getErrorCode())
+  + "\n Error State: " + (errorPresent() ? "Yes" : "No")
+  + " ErrorCode: " + format_hex(getErrorCode())
   + " ShortCode: " + getShortCode() + "(" + format_hex(getRawShortCode()) + ")"
   );
 }
@@ -210,7 +212,6 @@ std::string ErrorStateGetResponsePacket::getShortCode() const {
 
   auto lowBits = errorCode & 0x1F;
   if (lowBits > 0x15) {
-    ESP_LOGW(PACKETS_TAG, "Error lowbits %x were out of range.", lowBits);
     char buf[7];
     sprintf(buf, "ERR_%x", errorCode);
     return buf;

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -206,11 +206,11 @@ std::string ThermostatHelloRequestPacket::getThermostatVersionString() const {
 
 // ErrorStateGetResponsePacket functions
 std::string ErrorStateGetResponsePacket::getShortCode() const {
-  const auto upperAlphabet = "AbEFJLPU";
-  const auto lowerAlphabet = "0123456789ABCDEFOHJLPU";
-  const auto errorCode = this->getRawShortCode();
+  const char* upperAlphabet = "AbEFJLPU";
+  const char* lowerAlphabet = "0123456789ABCDEFOHJLPU";
+  const uint8_t errorCode = this->getRawShortCode();
 
-  auto lowBits = errorCode & 0x1F;
+  uint8_t lowBits = errorCode & 0x1F;
   if (lowBits > 0x15) {
     char buf[7];
     sprintf(buf, "ERR_%x", errorCode);

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -180,6 +180,10 @@ class GetRequestPacket : public Packet {
     static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::status);
     return INSTANCE;
   }
+  static GetRequestPacket& getErrorInfoInstance() {
+    static GetRequestPacket INSTANCE = GetRequestPacket(GetCommand::error_info);
+    return INSTANCE;
+  }
   using Packet::Packet;
 
  private:

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -257,7 +257,10 @@ class ErrorStateGetResponsePacket : public Packet {
   using Packet::Packet;
  public:
   uint16_t getErrorCode() const {return pkt_.getPayloadByte(4) << 8 | pkt_.getPayloadByte(5);}
-  uint8_t getShortCode() const {return pkt_.getPayloadByte(6);}
+  uint8_t getRawShortCode() const {return pkt_.getPayloadByte(6);}
+  std::string getShortCode() const;
+
+  bool errorPresent() const { return getErrorCode() == 0x8000 && getRawShortCode() == 0x00; }
 
   std::string to_string() const override;
 };

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -264,7 +264,7 @@ class ErrorStateGetResponsePacket : public Packet {
   uint8_t getRawShortCode() const {return pkt_.getPayloadByte(6);}
   std::string getShortCode() const;
 
-  bool errorPresent() const { return getErrorCode() == 0x8000 && getRawShortCode() == 0x00; }
+  bool errorPresent() const { return getErrorCode() != 0x8000 || getRawShortCode() != 0x00; }
 
   std::string to_string() const override;
 };

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -33,7 +33,7 @@ enum class PacketType : uint8_t {
 enum class GetCommand : uint8_t {
   settings = 0x02,
   current_temp = 0x03,
-  four = 0x04,
+  error_info = 0x04,
   status = 0x06,
   standby = 0x09,
   a_9 = 0xa9


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity, and (mostly) resolves #16.

- Create a Text Sensor that will report error state to HA as a string.
  - Priority is given to two-digit errors, and then the standard `ushort` error code.
- Add a rudimentary timer to check for new errors every ~10 or so cycles.
  - Only runs if a thermostat is not detected.
- Convert two-digit error codes to the Mitsubishi-readable format.
- Properly categorizes AG 0x04 as error information.