### PR TITLE
feat: Start Autoconf Framework

### DIFF
--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -48,7 +48,8 @@ void MitsubishiUART::processPacket(const ExtendedConnectResponsePacket &packet) 
   // Not sure if there's any needed content in this response, so assume we're connected.
   // TODO: Is there more useful info in these?
   hpConnected = true;
-  ESP_LOGI(TAG, "Heatpump connected.");
+  _capabilitiesCache = packet;
+  ESP_LOGI(TAG, "Received heat pump identification packet.");
 };
 
 void MitsubishiUART::processPacket(const GetRequestPacket &packet) {

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -118,6 +118,12 @@ void MitsubishiUART::update() {
     return;
   }
 
+  // Block until we get our extended capabilities information.
+  if (!_capabilitiesCache.has_value()) {
+    IFACTIVE(hp_bridge.sendPacket(ExtendedConnectRequestPacket::instance());)
+    return;
+  }
+
   // Before requesting additional updates, publish any changes waiting from packets received
   if (publishOnUpdate){
     doPublish();

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -118,10 +118,14 @@ void MitsubishiUART::update() {
     return;
   }
 
-  // Block until we get our extended capabilities information.
-  if (!_capabilitiesCache.has_value()) {
-    IFACTIVE(hp_bridge.sendPacket(ExtendedConnectRequestPacket::instance());)
-    return;
+  // Attempt to read capabilities on the next loop after connect.
+  // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper autoconf.
+  //       For now, just requesting it as part of our "init loops" is a good first step.
+  if (!this->_capabilitiesRequested) {
+    IFACTIVE(
+    hp_bridge.sendPacket(ExtendedConnectRequestPacket::instance());
+    this->_capabilitiesRequested = true;
+    )
   }
 
   // Before requesting additional updates, publish any changes waiting from packets received

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -143,6 +143,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     bool publishOnUpdate = false;
 
     optional<ExtendedConnectResponsePacket> _capabilitiesCache;
+    bool _capabilitiesRequested = false;
 
     // Preferences
     void save_preferences();

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -142,6 +142,8 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Should we call publish on the next update?
     bool publishOnUpdate = false;
 
+    optional<ExtendedConnectResponsePacket> _capabilitiesCache;
+
     // Preferences
     void save_preferences();
     void restore_preferences();

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -97,9 +97,8 @@ class ExtendedConnectRequestPacket : public Packet {
   }
   using Packet::Packet;
  private:
-  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::extended_connect_request, 2)) {
-    pkt_.setPayloadByte(0, 0xca);
-    pkt_.setPayloadByte(1, 0x01);
+  ExtendedConnectRequestPacket() : Packet(RawPacket(PacketType::extended_connect_request, 1)) {
+    pkt_.setPayloadByte(0, 0xc9);
   }
 };
 

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -132,7 +132,7 @@ class ExtendedConnectResponsePacket : public Packet {
   float getMaxAutoSetpoint() const { return ((int) pkt_.getPayloadByte(15) - 128) / 2.0f; }
 
   // Things that have to exist, but we don't know where yet.
-  bool supportsHVaneSwing() const { return this->supportsVaneSwing(); }
+  bool supportsHVaneSwing() const { return true; }
 
   // Fan Speeds TODO: Probably move this to .cpp?
   uint8_t getSupportedFanSpeeds() const;

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -132,7 +132,7 @@ class ExtendedConnectResponsePacket : public Packet {
   float getMaxAutoSetpoint() const { return ((int) pkt_.getPayloadByte(15) - 128) / 2.0f; }
 
   // Things that have to exist, but we don't know where yet.
-  bool supportsHVaneSwing() const { return false; }
+  bool supportsHVaneSwing() const { return this->supportsVaneSwing(); }
 
   // Fan Speeds TODO: Probably move this to .cpp?
   uint8_t getSupportedFanSpeeds() const;


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity, and starts work on #12.

- Fix a bug where the auto fan flag wasn't properly inverted.
- Move supported fan speeds to the `.cpp` file for packets.
- Add skeleton `packet.asTraits()` to quickly get core heatpump-supported features.
  - Not to be used directly, as any integration may still build their own custom traits.
- Always request extended connect information as part of boot cycle, and cache the results.