### PR TITLE
feat: Legacy Temperature Support

### DIFF
--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -142,10 +142,10 @@ float SettingsGetResponsePacket::getTargetTemp() const {
 
   if (enhancedTemperature == 0x00) {
     auto legacyTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
-    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)legacyTemperature / 0x10));
+    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)(legacyTemperature & 0x10)));
   }
 
-  return ((float) pkt_.getPayloadByte(PLINDEX_TARGETTEMP) - 128) / 2.0f;
+  return ((float)enhancedTemperature - 128) / 2.0f;
 }
 
 

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -136,6 +136,18 @@ SettingsSetRequestPacket &SettingsSetRequestPacket::setHorizontalVane(const HORI
   return *this;
 }
 
+// SettingsGetResponsePacket functions
+float SettingsGetResponsePacket::getTargetTemp() const {
+  auto enhancedTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP);
+
+  if (enhancedTemperature == 0x00) {
+    auto legacyTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
+    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)legacyTemperature / 0x10));
+  }
+
+  return ((float) pkt_.getPayloadByte(PLINDEX_TARGETTEMP) - 128) / 2.0f;
+}
+
 
 // RemoteTemperatureSetRequestPacket functions
 
@@ -151,6 +163,17 @@ RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::setRemoteT
 RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::useInternalTemperature() {
   setFlags(0x00);  // Set flags to say to use internal temperature
   return *this;
+}
+
+// CurrentTempGetResponsePacket functions
+float CurrentTempGetResponsePacket::getCurrentTemp() const {
+  auto enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_CURRENTTEMP);
+
+  //TODO: Figure out how to handle "out of range" issues here.
+  if (enhancedRawTemp == 0)
+    return 8 + ((float) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP_LEGACY) * 0.5f);
+
+  return ((float) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP) - 128) / 2.0f;
 }
 
 }  // namespace mitsubishi_uart

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -138,14 +138,14 @@ SettingsSetRequestPacket &SettingsSetRequestPacket::setHorizontalVane(const HORI
 
 // SettingsGetResponsePacket functions
 float SettingsGetResponsePacket::getTargetTemp() const {
-  auto enhancedTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP);
+  uint8_t enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_TARGETTEMP);
 
-  if (enhancedTemperature == 0x00) {
-    auto legacyTemperature = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
-    return ((float)(31 - (legacyTemperature % 0x10)) + (0.5f * (float)(legacyTemperature & 0x10)));
+  if (enhancedRawTemp == 0x00) {
+    uint8_t legacyRawTemp = pkt_.getPayloadByte(PLINDEX_TARGETTEMP_LEGACY);
+    return ((float)(31 - (legacyRawTemp % 0x10)) + (0.5f * (float)(legacyRawTemp & 0x10)));
   }
 
-  return ((float)enhancedTemperature - 128) / 2.0f;
+  return ((float)enhancedRawTemp - 128) / 2.0f;
 }
 
 
@@ -167,13 +167,13 @@ RemoteTemperatureSetRequestPacket &RemoteTemperatureSetRequestPacket::useInterna
 
 // CurrentTempGetResponsePacket functions
 float CurrentTempGetResponsePacket::getCurrentTemp() const {
-  auto enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_CURRENTTEMP);
+  uint8_t enhancedRawTemp = pkt_.getPayloadByte(PLINDEX_CURRENTTEMP);
 
   //TODO: Figure out how to handle "out of range" issues here.
   if (enhancedRawTemp == 0)
     return 8 + ((float) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP_LEGACY) * 0.5f);
 
-  return ((float) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP) - 128) / 2.0f;
+  return ((float) enhancedRawTemp - 128) / 2.0f;
 }
 
 }  // namespace mitsubishi_uart

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -191,6 +191,7 @@ class GetRequestPacket : public Packet {
 class SettingsGetResponsePacket : public Packet {
   static const int PLINDEX_POWER = 3;
   static const int PLINDEX_MODE = 4;
+  static const int PLINDEX_TARGETTEMP_LEGACY = 5;
   static const int PLINDEX_FAN = 6;
   static const int PLINDEX_VANE = 7;
   static const int PLINDEX_PROHIBITFLAGS = 8;
@@ -207,7 +208,8 @@ class SettingsGetResponsePacket : public Packet {
   bool lockedMode() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x02; }
   bool lockedTemp() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x04; }
   uint8_t getHorizontalVane() const { return pkt_.getPayloadByte(PLINDEX_HVANE); }
-  float getTargetTemp() const { return ((int) pkt_.getPayloadByte(PLINDEX_TARGETTEMP) - 128) / 2.0f; }
+
+  float getTargetTemp() const;
 
   std::string to_string() const override;
 };
@@ -218,7 +220,7 @@ class CurrentTempGetResponsePacket : public Packet {
   using Packet::Packet;
 
  public:
-  float getCurrentTemp() const { return ((int) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP) - 128) / 2.0f; }
+  float getCurrentTemp() const;
   std::string to_string() const override;
 };
 


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity.

- Falls back to using the legacy temperature scale(s) when an enhanced-range/enhanced-precision temperature was not provided.