### PR TITLE
feat: Expose Actual Fan Speed Properly

### DIFF
--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -100,10 +100,10 @@ SENSORS = {
     ),
     "actual_fan": (
         "Actual Fan Speed",
-        sensor.sensor_schema(
-            device_class=DEVICE_CLASS_SPEED,
+        text_sensor.text_sensor_schema(
+            icon="mdi:fan",
         ),
-        sensor.register_sensor
+        text_sensor.register_text_sensor
     ),
     "service_filter": (
         "Service Filter",

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -279,8 +279,8 @@ void MitsubishiUART::processPacket(const StandbyGetResponsePacket &packet) {
   }
 
   if (actual_fan_sensor) {
-    const uint8_t old_actual_fan = actual_fan_sensor->raw_state;
-    actual_fan_sensor->raw_state = packet.getActualFanSpeed();
+    const auto old_actual_fan = actual_fan_sensor->raw_state;
+    actual_fan_sensor->raw_state = ACTUAL_FAN_SPEED_NAMES[packet.getActualFanSpeed()];
     publishOnUpdate |= (old_actual_fan != actual_fan_sensor->raw_state);
   }
 

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -27,6 +27,11 @@ const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000; // (7min) The heatpump wi
 
 const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
+// these names come from Kumo. They are bad, but I am also too lazy to think of better names. they also
+// may not map perfectly yet?
+const std::array<std::string, 7> ACTUAL_FAN_SPEED_NAMES = {"Off", "Very Low", "Quiet", "Low", "Powerful",
+                                                           "Super Powerful", "Super Quiet"};
+
 class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
  public:
   /**
@@ -64,7 +69,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Sensor setters
   void set_thermostat_temperature_sensor(sensor::Sensor *sensor) {thermostat_temperature_sensor = sensor;};
   void set_compressor_frequency_sensor(sensor::Sensor *sensor) {compressor_frequency_sensor = sensor;};
-  void set_actual_fan_sensor(sensor::Sensor *sensor) {actual_fan_sensor = sensor;};
+  void set_actual_fan_sensor(text_sensor::TextSensor *sensor) {actual_fan_sensor = sensor;};
   void set_service_filter_sensor(binary_sensor::BinarySensor *sensor) {service_filter_sensor = sensor;};
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {defrost_sensor = sensor;};
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) {hot_adjust_sensor = sensor;};
@@ -145,7 +150,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     // Internal sensors
     sensor::Sensor *thermostat_temperature_sensor = nullptr;
     sensor::Sensor *compressor_frequency_sensor = nullptr;
-    sensor::Sensor *actual_fan_sensor = nullptr;
+    text_sensor::TextSensor *actual_fan_sensor = nullptr;
     binary_sensor::BinarySensor *service_filter_sensor = nullptr;
     binary_sensor::BinarySensor *defrost_sensor = nullptr;
     binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -60,7 +60,7 @@ std::string StandbyGetResponsePacket::to_string() const {
   + " Defrost:" + (inDefrost()?"Yes":"No")
   + " HotAdjust:" + (inHotAdjust()?"Yes":"No")
   + " Standby:" + (inStandby()?"Yes":"No")
-  + " ActualFan:" + std::to_string(getActualFanSpeed())
+  + " ActualFan:" + ACTUAL_FAN_SPEED_NAMES[getActualFanSpeed()] + " (" + std::to_string(getActualFanSpeed()) + ")"
   + " AutoMode:" + format_hex(getAutoMode())
   );
 }


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity.

- Converts the "Actual Fan Speed" sensor to a TextSensor, using Kumo names
- Add the Actual Fan Speed name to the log file as well for debug purposes.