### PR TITLE
feat: Add ThermostatHello packet handling

### DIFF
--- a/components/mitsubishi_uart/muart_bridge.cpp
+++ b/components/mitsubishi_uart/muart_bridge.cpp
@@ -180,8 +180,8 @@ void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
       case SetCommand::settings :
         processRawPacket<SettingsSetRequestPacket>(pkt, true);
         break;
-      case SetCommand::a_7 :
-        processRawPacket<A7SetRequestPacket>(pkt, false);
+      case SetCommand::thermostat_hello :
+        processRawPacket<ThermostatHelloRequestPacket>(pkt, false);
         break;
       default:
         processRawPacket<Packet>(pkt, true);

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -1,4 +1,5 @@
 #include "muart_packet.h"
+#include "muart_utils.h"
 
 namespace esphome {
 namespace mitsubishi_uart {
@@ -84,6 +85,12 @@ std::string RemoteTemperatureSetRequestPacket::to_string() const {
   + "\n Temp:" + std::to_string(getRemoteTemperature()));
 }
 
+std::string ThermostatHelloRequestPacket::to_string() const {
+  return("Thermostat Hello: " + Packet::to_string() + CONSOLE_COLOR_PURPLE +
+          "\n Model: " + getThermostatModel() +
+          " Serial: " + getThermostatSerial() +
+          " Version: " + getThermostatVersionString());
+}
 
 // TODO: Are there function implementations for packets in the .h file? (Yes)  Should they be here?
 
@@ -174,6 +181,25 @@ float CurrentTempGetResponsePacket::getCurrentTemp() const {
     return 8 + ((float) pkt_.getPayloadByte(PLINDEX_CURRENTTEMP_LEGACY) * 0.5f);
 
   return ((float) enhancedRawTemp - 128) / 2.0f;
+}
+
+// ThermostatHelloRequestPacket functions
+std::string ThermostatHelloRequestPacket::getThermostatModel() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 1), 3, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatSerial() const {
+  return MUARTUtils::DecodeNBitString((pkt_.getBytes() + 4), 8, 6);
+}
+
+std::string ThermostatHelloRequestPacket::getThermostatVersionString() const {
+  char buf[16];
+  sprintf(buf, "%02d.%02d.%02d",
+          pkt_.getPayloadByte(13),
+          pkt_.getPayloadByte(14),
+          pkt_.getPayloadByte(15));
+
+  return buf;
 }
 
 }  // namespace mitsubishi_uart

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -364,12 +364,18 @@ public:
 };
 
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
-class A7SetRequestPacket : public Packet {
+class ThermostatHelloRequestPacket : public Packet {
   using Packet::Packet;
  public:
-  A7SetRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
-    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::a_7));
+  ThermostatHelloRequestPacket() : Packet(RawPacket(PacketType::set_request, 4)) {
+    pkt_.setPayloadByte(0, static_cast<uint8_t>(SetCommand::thermostat_hello));
   }
+
+  std::string getThermostatModel() const;
+  std::string getThermostatSerial() const;
+  std::string getThermostatVersionString() const;
+
+  std::string to_string() const override;
 };
 
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -43,7 +43,7 @@ enum class GetCommand : uint8_t {
 enum class SetCommand : uint8_t {
   settings = 0x01,
   remote_temperature = 0x07,
-  a_7 = 0xa7
+  thermostat_hello = 0xa7
 };
 
 // Which MUARTBridge was the packet read from (used to determine flow direction of the packet)

--- a/components/mitsubishi_uart/muart_utils.h
+++ b/components/mitsubishi_uart/muart_utils.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "mitsubishi_uart.h"
+
+namespace esphome {
+namespace mitsubishi_uart {
+
+class MUARTUtils {
+ public:
+  static std::string DecodeNBitString(const uint8_t data[], size_t dataLength, size_t wordSize) {
+    auto resultLength = (dataLength / wordSize) + (dataLength % wordSize != 0);
+    auto result = std::string();
+
+    for (int i = 0; i < resultLength; i++) {
+      auto bits = BitSlice(data, i * wordSize, ((i + 1) * wordSize) - 1);
+      if (bits <= 0x1F) bits += 0x40;
+      result += (char)bits;
+    }
+
+    return result;
+  }
+
+ private:
+  static uint64_t BitSlice(const uint8_t ds[], size_t start, size_t end) {
+    // Lazies! https://stackoverflow.com/a/25297870/1817097
+    uint64_t s = 0;
+    size_t i, n = (end - 1) / 8;
+    for(i = 0; i <= n; ++i)
+      s = (s << 8) + ds[i];
+    s >>= (n+1) * 8 - end;
+    uint64_t mask = (((uint64_t)1) << (end - start + 1))-1;//len = end - start + 1
+    s &= mask;
+    return s;
+  }
+};
+
+}  // namespace mitsubishi_uart
+}  // namespace esphome

--- a/components/mitsubishi_uart/muart_utils.h
+++ b/components/mitsubishi_uart/muart_utils.h
@@ -7,6 +7,8 @@ namespace mitsubishi_uart {
 
 class MUARTUtils {
  public:
+  /// Read a string out of data, wordSize bits at a time.
+  /// Used to decode serial numbers and other information from a thermostat.
   static std::string DecodeNBitString(const uint8_t data[], size_t dataLength, size_t wordSize) {
     auto resultLength = (dataLength / wordSize) + (dataLength % wordSize != 0);
     auto result = std::string();
@@ -21,6 +23,7 @@ class MUARTUtils {
   }
 
  private:
+  /// Extract the specified bits (inclusive) from an arbitrarily-sized byte array. Does not perform bounds checks.
   static uint64_t BitSlice(const uint8_t ds[], size_t start, size_t end) {
     // Lazies! https://stackoverflow.com/a/25297870/1817097
     uint64_t s = 0;


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity.

- Adds experimental logging for the ThermostatHello packet.
- Adds methods to decode the n-bit encoding Mitsubishi uses.
- Reclassifies AG A7 into ThermostatHello