### PR TITLE
chore/fix: Use ESPHome editor configs, boring fixes.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseTab:          Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,171 @@
+---
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
+  -bugprone-signed-char-misuse,
+  -cert-dcl50-cpp,
+  -cert-err33-c,
+  -cert-err58-cpp,
+  -cert-oop57-cpp,
+  -cert-str34-c,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-osx.*,
+  -clang-diagnostic-delete-abstract-non-virtual-dtor,
+  -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-ignored-optimization-argument,
+  -clang-diagnostic-shadow-field,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
+  -concurrency-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-virtual-class-destructor,
+  -fuchsia-multiple-inheritance,
+  -fuchsia-overloaded-operator,
+  -fuchsia-statically-constructed-objects,
+  -fuchsia-default-arguments-declarations,
+  -fuchsia-default-arguments-calls,
+  -google-build-using-namespace,
+  -google-explicit-constructor,
+  -google-readability-braces-around-statements,
+  -google-readability-casting,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -google-runtime-references,
+  -hicpp-*,
+  -llvm-else-after-return,
+  -llvm-header-guard,
+  -llvm-include-order,
+  -llvm-qualified-auto,
+  -llvmlibc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
+  -misc-unused-parameters,
+  -modernize-avoid-c-arrays,
+  -modernize-avoid-bind,
+  -modernize-concat-nested-namespaces,
+  -modernize-return-braced-init-list,
+  -modernize-use-auto,
+  -modernize-use-default-member-init,
+  -modernize-use-equals-default,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -mpi-*,
+  -objc-*,
+  -readability-container-data-pointer,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-redundant-string-init,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+WarningsAsErrors: '*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     google
+CheckOptions:
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
+    value:           0

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+root = true
+
+# general
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# C++
+[*.{cpp,h,tcc}]
+indent_style = space
+indent_size = 2
+
+# Web
+[*.{js,html,css}]
+indent_style = space
+indent_size = 2
+
+# YAML
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+quote_type = double
+
+# JSON
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize line endings to LF in the repository
+* text eol=lf
+*.png binary

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,18 @@
+---
+extends: default
+
+ignore-from-file: .gitignore
+
+rules:
+  document-start: disable
+  empty-lines:
+    level: error
+    max: 1
+    max-start: 0
+    max-end: 1
+  indentation:
+    level: error
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  line-length: disable

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -176,7 +176,7 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
       horizontal_vane_position_select->state = "Swing";
       break;
     default:
-      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.getVane());
+      ESP_LOGW(TAG, "Vane in unknown horizontal position %x", packet.getHorizontalVane());
   }
   publishOnUpdate |= (old_horizontal_vane_position != horizontal_vane_position_select->state);
 };

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -31,7 +31,7 @@ class Packet {
 
     // Is a response packet expected when this packet is sent.  Defaults to true since
     // most requests receive a response.
-    const bool isResponseExpected() const {return responseExpected;};
+    bool isResponseExpected() const {return responseExpected;};
     void setResponseExpected(bool expectResponse) {responseExpected = expectResponse;};
 
     // Passthrough methods to RawPacket

--- a/components/mitsubishi_uart/muart_rawpacket.h
+++ b/components/mitsubishi_uart/muart_rawpacket.h
@@ -80,7 +80,7 @@ class RawPacket {
 
   virtual std::string to_string() const {return format_hex_pretty(&getBytes()[0], getLength());};
 
-  const uint8_t getLength() const { return length; };
+  uint8_t getLength() const { return length; };
   const uint8_t *getBytes() const { return packetBytes; };  // Primarily for sending packets
 
   bool isChecksumValid() const;

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,30 @@
+[MASTER]
+reports=no
+ignore=api_pb2.py
+
+disable=
+  format,
+  missing-docstring,
+  fixme,
+  unused-argument,
+  global-statement,
+  too-few-public-methods,
+  too-many-lines,
+  too-many-locals,
+  too-many-ancestors,
+  too-many-branches,
+  too-many-statements,
+  too-many-arguments,
+  too-many-return-statements,
+  too-many-instance-attributes,
+  duplicate-code,
+  invalid-name,
+  cyclic-import,
+  redefined-builtin,
+  undefined-loop-variable,
+  useless-object-inheritance,
+  stop-iteration-return,
+  import-outside-toplevel,
+  # Broken
+  unsupported-membership-test,
+  unsubscriptable-object,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[flake8]
+max-line-length = 120
+# Following 4 for black compatibility
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+
+# TODO fix flake8
+# D100 Missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+# D105 Missing docstring in magic method
+# D107 Missing docstring in __init__
+# D200 One-line docstring should fit on one line with quotes
+# D205 1 blank line required between summary line and description
+# D209 Multi-line docstring closing quotes should be on a separate line
+# D400 First line should end with a period
+# D401 First line should be in imperative mood
+
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+
+    D100,
+    D101,
+    D102,
+    D103,
+    D104,
+    D105,
+    D107,
+    D200,
+    D205,
+    D209,
+    D400,
+    D401,


### PR DESCRIPTION
Pulled out of the PR #17 for maintainer sanity.

- Wholesale copies linter and IDE settings from the ESPHome repo.
- Fix the Horizontal Vane log message accidentally logging vertical vane state.
- Suppress some warnings emitted during build when using the ESP_IDF framework.