### PR TITLE
When active mode is off, pass thermostat temps.

### DIFF
--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -314,9 +314,10 @@ void MitsubishiUART::processPacket(const ErrorStateGetResponsePacket &packet) {
 void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-  // Only send this temperature packet to the heatpump if Thermostat is the selected source, otherwise
-  // just respond to the thermostat to keep it happy.
-  if (currentTemperatureSource == TEMPERATURE_SOURCE_THERMOSTAT) {
+  // Only send this temperature packet to the heatpump if Thermostat is the selected source,
+  // or we're in passive mode (since in passive mode we're not generating any packets to
+  // set the temperature) otherwise just respond to the thermostat to keep it happy.
+  if (currentTemperatureSource == TEMPERATURE_SOURCE_THERMOSTAT || !active_mode) {
     routePacket(packet);
   } else {
     ts_bridge->sendPacket(RemoteTemperatureSetResponsePacket());


### PR DESCRIPTION
Currently if the temperature source is set to an extra sensor (not Internal or Thermostat), but active mode is off, the controller will block any temperature updates (because it's not generating any packets of its own).  This fixes that by allowing thermostat remote temperature packets through when Active Mode is off.