### PR TITLE
fix: Change vane trait logic

### DIFF
--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -55,7 +55,7 @@ CUSTOM_FAN_MODES = {
     "VERYHIGH": mitsubishi_uart_ns.FAN_MODE_VERYHIGH
 }
 VANE_POSITIONS = ["Auto","1","2","3","4","5","Swing"]
-HORIZONTAL_VANE_POSITIONS = ["<<","<","|",">",">>","<>","Swing"]
+HORIZONTAL_VANE_POSITIONS = ["Auto","<<","<","|",">",">>","<>","Swing"]
 
 INTERNAL_TEMPERATURE_SOURCE_OPTIONS = [mitsubishi_uart_ns.TEMPERATURE_SOURCE_INTERNAL] # These will always be available
 

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -155,6 +155,9 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
 
   const std::string old_horizontal_vane_position = horizontal_vane_position_select->state;
   switch(packet.getHorizontalVane()) {
+    case SettingsSetRequestPacket::HV_AUTO:
+      horizontal_vane_position_select->state = "Auto";
+      break;
     case SettingsSetRequestPacket::HV_LEFT_FULL:
       horizontal_vane_position_select->state = "<<";
       break;

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -235,7 +235,9 @@ bool MitsubishiUART::select_horizontal_vane_position(const std::string &state) {
   // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
   // infrequently, this is probably a better solution than over-optimizing via maps or something
 
-  if (state == "<<") {
+  if (state == "Auto") {
+    positionByte = SettingsSetRequestPacket::HV_AUTO;
+  } else if (state == "<<") {
     positionByte = SettingsSetRequestPacket::HV_LEFT_FULL;
   } else if (state == "<") {
     positionByte = SettingsSetRequestPacket::HV_LEFT;

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -255,12 +255,16 @@ climate::ClimateTraits ExtendedConnectResponsePacket::asTraits() const {
   if (!this->isFanDisabled())
     ct.add_supported_mode(climate::CLIMATE_MODE_FAN_ONLY);
 
-  if (this->supportsVaneSwing() && this->supportsHVaneSwing())
-    ct.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
-  if (this->supportsVaneSwing())
-    ct.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
-  if (this->supportsHVaneSwing())
-    ct.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+  if (this->supportsVaneSwing()) {
+      ct.add_supported_swing_mode(climate::CLIMATE_SWING_OFF);
+
+      if (this->supportsVane() && this->supportsHVane())
+        ct.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
+      if (this->supportsVane())
+        ct.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
+      if (this->supportsHVane())
+        ct.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
+  }
 
   ct.set_visual_min_temperature(std::min(this->getMinCoolDrySetpoint(), this->getMinHeatingSetpoint()));
   ct.set_visual_max_temperature(std::max(this->getMaxCoolDrySetpoint(), this->getMaxHeatingSetpoint()));

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -132,7 +132,7 @@ class ExtendedConnectResponsePacket : public Packet {
   float getMaxAutoSetpoint() const { return ((int) pkt_.getPayloadByte(15) - 128) / 2.0f; }
 
   // Things that have to exist, but we don't know where yet.
-  bool supportsHVaneSwing() const { return true; }
+  bool supportsHVane() const { return true; }
 
   // Fan Speeds TODO: Probably move this to .cpp?
   uint8_t getSupportedFanSpeeds() const;
@@ -308,6 +308,7 @@ class SettingsSetRequestPacket : public Packet {
   };
 
   enum HORIZONTAL_VANE_BYTE : uint8_t {
+    HV_AUTO = 0x00,
     HV_LEFT_FULL = 0x01,
     HV_LEFT = 0x02,
     HV_CENTER = 0x03,


### PR DESCRIPTION
Per pymelcloud, the bit for vane swing controls both horizontal and vertical vanes, with the former instead being controlled by a different (as-yet unidentified) byte.

Also adds a documented "auto" mode from the same repo (though this is sadly untested - still no horizontal vane on my unit…) 