### PR TITLE
fix: Support legacy temperatures everywhere

### DIFF
--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -205,7 +205,7 @@ class SettingsGetResponsePacket : public Packet {
 };
 
 class CurrentTempGetResponsePacket : public Packet {
-  static const int PLINDEX_CURRENTTEMP_LEGACY = 3;  // TODO: I don't know why I would use this instead of the one below...
+  static const int PLINDEX_CURRENTTEMP_LEGACY = 3;
   static const int PLINDEX_CURRENTTEMP = 6;
   using Packet::Packet;
 

--- a/components/mitsubishi_uart/muart_utils.h
+++ b/components/mitsubishi_uart/muart_utils.h
@@ -31,25 +31,19 @@ class MUARTUtils {
     if (value < -64) return 0;
     if (value > 63.5f) return 0xFF;
 
-    float whole, fractional;
-    fractional = std::modf(value, &whole);
-
-    return (uint8_t) (whole * 2) + (fractional >= 0.5 ? 1 : 0) + 128;
+    return (uint8_t) round(value * 2) + 128;
   }
 
   static float LegacyTargetTempToDegC(const uint8_t value) {
-    return ((float)(31 - (value % 0x10)) + (((value & 0x10) > 0) ? 0.5f : 0));
+    return ((float)(31 - (value & 0x0F)) + (((value & 0xF0) > 0) ? 0.5f : 0));
   }
 
   static uint8_t DegCToLegacyTargetTemp(const float value) {
     // Special cases per docs
-    if (value < 16) return 0x00;
-    if (value > 31.5) return 0x1F;
+    if (value < 16) return 0x0F;
+    if (value > 31.5) return 0x10;
 
-    float whole, fractional;
-    fractional = std::modf(value, &whole);
-
-    return (int)(whole - 16) + (int)((fractional >= 0.5) ? 0x10 : 0);
+    return ((31 - (uint8_t) value) & 0xF) + (((int) (value * 2) % 2) << 4);
   }
 
   static float LegacyRoomTempToDegC(const uint8_t value) {
@@ -61,10 +55,7 @@ class MUARTUtils {
     if (value < 8.5f) return 0x00;
     if (value > 32) return 0x31;
 
-    float whole, fractional;
-    fractional = std::modf(value, &whole);
-
-    return (uint8_t) (whole * 2) + (fractional >= 0.5 ? 1 : 0) - 16;
+    return (uint8_t) round(value * 2) - 16;
   }
 
  private:

--- a/components/mitsubishi_uart/muart_utils.h
+++ b/components/mitsubishi_uart/muart_utils.h
@@ -22,6 +22,51 @@ class MUARTUtils {
     return result;
   }
 
+  static float TempScaleAToDegC(const uint8_t value) {
+    return (float)(value - 128) / 2.0f;
+  }
+
+  static uint8_t DegCToTempScaleA(const float value) {
+    // Special cases
+    if (value < -64) return 0;
+    if (value > 63.5f) return 0xFF;
+
+    float whole, fractional;
+    fractional = std::modf(value, &whole);
+
+    return (uint8_t) (whole * 2) + (fractional >= 0.5 ? 1 : 0) + 128;
+  }
+
+  static float LegacyTargetTempToDegC(const uint8_t value) {
+    return ((float)(31 - (value % 0x10)) + (((value & 0x10) > 0) ? 0.5f : 0));
+  }
+
+  static uint8_t DegCToLegacyTargetTemp(const float value) {
+    // Special cases per docs
+    if (value < 16) return 0x00;
+    if (value > 31.5) return 0x1F;
+
+    float whole, fractional;
+    fractional = std::modf(value, &whole);
+
+    return (int)(whole - 16) + (int)((fractional >= 0.5) ? 0x10 : 0);
+  }
+
+  static float LegacyRoomTempToDegC(const uint8_t value) {
+    return 8 + ((float)value * 0.5f);
+  }
+
+  static uint8_t DegCToLegacyRoomTemp(const float value) {
+    // Special cases per docs
+    if (value < 8.5f) return 0x00;
+    if (value > 32) return 0x31;
+
+    float whole, fractional;
+    fractional = std::modf(value, &whole);
+
+    return (uint8_t) (whole * 2) + (fractional >= 0.5 ? 1 : 0) - 16;
+  }
+
  private:
   /// Extract the specified bits (inclusive) from an arbitrarily-sized byte array. Does not perform bounds checks.
   static uint64_t BitSlice(const uint8_t ds[], size_t start, size_t end) {


### PR DESCRIPTION
- Move legacy temperature conversions to MUARTUtils
- Update (hopefully) everything to support both legacy and A-scale temperature units
- Fix some possible edge case rounding bugs.
- Some minor automagic code cleanup.