### PR TITLE
feat: Add MSB field for Horizontal Vane

### DIFF
--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -49,7 +49,7 @@ std::string SettingsGetResponsePacket::to_string() const {
   + " Power:" + (getPower()==3 ? "Test" : getPower()>0 ? "On" : "Off")
   + " TargetTemp:" + std::to_string(getTargetTemp())
   + " Vane:" + format_hex(getVane())
-  + " HVane:" + format_hex(getHorizontalVane())
+  + " HVane:" + format_hex(getHorizontalVane()) + (getHorizontalVaneMSB() ? " (MSB Set)" : "")
   + "\n PowerLock:" + (lockedPower()?"Yes":"No")
   + " ModeLock:" + (lockedMode()?"Yes":"No")
   + " TempLock:" + (lockedTemp()?"Yes":"No")

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -197,7 +197,8 @@ class SettingsGetResponsePacket : public Packet {
   bool lockedPower() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x01; }
   bool lockedMode() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x02; }
   bool lockedTemp() const { return pkt_.getPayloadByte(PLINDEX_PROHIBITFLAGS) & 0x04; }
-  uint8_t getHorizontalVane() const { return pkt_.getPayloadByte(PLINDEX_HVANE); }
+  uint8_t getHorizontalVane() const { return pkt_.getPayloadByte(PLINDEX_HVANE) & 0x7F; }
+  bool getHorizontalVaneMSB() const { return pkt_.getPayloadByte(PLINDEX_HVANE) & 0x80; }
 
   float getTargetTemp() const;
 


### PR DESCRIPTION
Reading the horizontal vane will now ignore the MSB, which is returned by some units for an unknown purpose. The remainder of the field is still captured in order to better track possible unknown values.

The MSB is available at a new field specific for it.

At present, the MSB will be unset for SetSettings packets, as it does not seem to be necessary. This may change in the future, but this is at least a starting point.