### PR TITLE
fix: Properly handle SetResponse packet logging

### DIFF
--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -337,11 +337,10 @@ void MitsubishiUART::processPacket(const RemoteTemperatureSetRequestPacket &pack
     publishOnUpdate |= (old_thermostat_temp != thermostat_temperature_sensor->raw_state);
   }
 };
-void MitsubishiUART::processPacket(const RemoteTemperatureSetResponsePacket &packet) {
+void MitsubishiUART::processPacket(const SetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.isSuccessful() ? "true" : "false", packet.getResultCode());
   routePacket(packet);
-  ESP_LOGI(TAG, "Unhandled packet RemoteTemperatureSetResponsePacket received.");
-  ESP_LOGD(TAG, "%s", packet.to_string().c_str());
-};
+}
 
 }  // namespace mitsubishi_uart
 }  // namespace esphome

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -111,7 +111,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     void processPacket(const StandbyGetResponsePacket &packet);
     void processPacket(const ErrorStateGetResponsePacket &packet);
     void processPacket(const RemoteTemperatureSetRequestPacket &packet);
-    void processPacket(const RemoteTemperatureSetResponsePacket &packet);
+    void processPacket(const SetResponsePacket &packet);
 
     void doPublish();
 

--- a/components/mitsubishi_uart/muart_bridge.cpp
+++ b/components/mitsubishi_uart/muart_bridge.cpp
@@ -188,13 +188,7 @@ void MUARTBridge::classifyAndProcessRawPacket(RawPacket &pkt) const {
     }
     break;
   case PacketType::set_response :
-    switch(static_cast<SetCommand>(pkt.getCommand())) {
-      case SetCommand::remote_temperature :
-        processRawPacket<RemoteTemperatureSetResponsePacket>(pkt, false);
-        break;
-      default:
-        processRawPacket<Packet>(pkt, false);
-    }
+    processRawPacket<SetResponsePacket>(pkt, false);
     break;
 
   default:

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -358,6 +358,15 @@ public:
   RemoteTemperatureSetResponsePacket() : Packet(RawPacket(PacketType::set_response, 16)) {}
 };
 
+class SetResponsePacket : public Packet {
+  using Packet::Packet;
+public:
+  SetResponsePacket() : Packet(RawPacket(PacketType::set_response, 16)) {}
+
+  uint8_t getResultCode() const { return pkt_.getPayloadByte(0); }
+  bool isSuccessful() const { return getResultCode() == 0; }
+};
+
 // Sent by MHK2 but with no response; defined to allow setResponseExpected(false)
 class ThermostatHelloRequestPacket : public Packet {
   using Packet::Packet;
@@ -396,7 +405,7 @@ class PacketProcessor {
     virtual void processPacket(const StandbyGetResponsePacket &packet) {};
     virtual void processPacket(const ErrorStateGetResponsePacket &packet) {};
     virtual void processPacket(const RemoteTemperatureSetRequestPacket &packet) {};
-    virtual void processPacket(const RemoteTemperatureSetResponsePacket &packet) {};
+    virtual void processPacket(const SetResponsePacket &packet) {};
 };
 
 }  // namespace mitsubishi_uart


### PR DESCRIPTION
Basically, don't actually do anything - it's just a (n)ACK.