### PR TITLE
feat: Add i-see support [MSZ-FS##NA]

### DIFF
--- a/components/mitsubishi_uart/__init__.py
+++ b/components/mitsubishi_uart/__init__.py
@@ -28,6 +28,7 @@ CONF_TS_UART = "thermostat_uart"
 CONF_SENSORS = "sensors"
 CONF_SENSORS_THERMOSTAT_TEMP = "thermostat_temperature"
 CONF_SENSORS_ERROR_CODE = "error_code"
+CONF_SENSORS_ISEE_STATUS ="isee_status"
 
 CONF_SELECTS = "selects"
 CONF_TEMPERATURE_SOURCE_SELECT = "temperature_source_select" # This is to create a Select object for selecting a source
@@ -124,6 +125,13 @@ SENSORS = {
     "standby": (
         "Standby",
         binary_sensor.binary_sensor_schema(),
+        binary_sensor.register_binary_sensor
+    ),
+    CONF_SENSORS_ISEE_STATUS: (
+        "i-see Status",
+        binary_sensor.binary_sensor_schema(
+            icon="mdi:eye"
+        ),
         binary_sensor.register_binary_sensor
     ),
     CONF_SENSORS_ERROR_CODE: (

--- a/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart-packetprocessing.cpp
@@ -70,18 +70,26 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
   if (packet.getPower()) {
     switch (packet.getMode()) {
       case 0x01:
+      case 0x09: // i-see
         mode = climate::CLIMATE_MODE_HEAT;
         break;
       case 0x02:
+      case 0x0A: // i-see
         mode = climate::CLIMATE_MODE_DRY;
         break;
       case 0x03:
+      case 0x0B: // i-see
         mode = climate::CLIMATE_MODE_COOL;
         break;
       case 0x07:
         mode = climate::CLIMATE_MODE_FAN_ONLY;
         break;
       case 0x08:
+        mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+      case 0x21:
+      case 0x23:
+        // unsure when these would ever be sent, as they seem to be Kumo exclusive, but let's handle them anyways.
         mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
       default:
@@ -92,6 +100,13 @@ void MitsubishiUART::processPacket(const SettingsGetResponsePacket &packet) {
   }
 
   publishOnUpdate |= (old_mode != mode);
+
+  // Mode (i-see)
+  if (isee_status_sensor) {
+    const bool old_isee_status = isee_status_sensor->state;
+    isee_status_sensor->state = packet.getiSeeStatus();
+    publishOnUpdate |= (old_isee_status != isee_status_sensor->state);
+  }
 
   // Temperature
   const float old_target_temperature = target_temperature;

--- a/components/mitsubishi_uart/mitsubishi_uart.cpp
+++ b/components/mitsubishi_uart/mitsubishi_uart.cpp
@@ -186,6 +186,7 @@ void MitsubishiUART::doPublish() {
   defrost_sensor->publish_state(defrost_sensor->state);
   hot_adjust_sensor->publish_state(hot_adjust_sensor->state);
   standby_sensor->publish_state(standby_sensor->state);
+  isee_status_sensor->publish_state(isee_status_sensor->state);
 }
 
 bool MitsubishiUART::select_temperature_source(const std::string &state) {

--- a/components/mitsubishi_uart/mitsubishi_uart.h
+++ b/components/mitsubishi_uart/mitsubishi_uart.h
@@ -77,6 +77,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void set_defrost_sensor(binary_sensor::BinarySensor *sensor) {defrost_sensor = sensor;};
   void set_hot_adjust_sensor(binary_sensor::BinarySensor *sensor) {hot_adjust_sensor = sensor;};
   void set_standby_sensor(binary_sensor::BinarySensor *sensor) {standby_sensor = sensor;};
+  void set_isee_status_sensor(binary_sensor::BinarySensor *sensor) { isee_status_sensor = sensor; }
   void set_error_code_sensor(text_sensor::TextSensor *sensor) { error_code_sensor = sensor; };
 
   // Select setters
@@ -162,6 +163,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
     binary_sensor::BinarySensor *defrost_sensor = nullptr;
     binary_sensor::BinarySensor *hot_adjust_sensor = nullptr;
     binary_sensor::BinarySensor *standby_sensor = nullptr;
+    binary_sensor::BinarySensor *isee_status_sensor = nullptr;
     text_sensor::TextSensor *error_code_sensor = nullptr;
 
     // Selects

--- a/components/mitsubishi_uart/muart_packet-derived.cpp
+++ b/components/mitsubishi_uart/muart_packet-derived.cpp
@@ -167,6 +167,14 @@ float SettingsGetResponsePacket::getTargetTemp() const {
   return MUARTUtils::TempScaleAToDegC(enhancedRawTemp);
 }
 
+bool SettingsGetResponsePacket::getiSeeStatus() const {
+  uint8_t mode = pkt_.getPayloadByte(PLINDEX_MODE);
+
+  // so far only modes 0x09 to 0x11 are known to be i-see. Mode 0x08 technically *can* be, but it's not a guarantee
+  // alone.
+  return (mode >= 0x09 && mode <= 0x11);
+}
+
 
 // RemoteTemperatureSetRequestPacket functions
 

--- a/components/mitsubishi_uart/muart_packet.h
+++ b/components/mitsubishi_uart/muart_packet.h
@@ -202,6 +202,8 @@ class SettingsGetResponsePacket : public Packet {
 
   float getTargetTemp() const;
 
+  bool getiSeeStatus() const;
+
   std::string to_string() const override;
 };
 


### PR DESCRIPTION
PR to add i-see things, necessary for the MSZ-FS##NA units. This will fix issues where these units will report as "off" to HA when they're using the i-see sensor for something.

There are still a few questions here that I've yet to explore:

- Is it possible to enable/disable i-see from CN105? Kumo's code says no, but that's been wrong before.
- Why does mode 0x08 get overwritten with a more specific mode?
  - Interestingly, the MHK2 tracks auto correctly, so something is hiding somewhere.
- Is there any other i-see specific data around (diagnostics, human detection, etc)?